### PR TITLE
Consistency/clarity updates for community-review-process

### DIFF
--- a/operational/community-review-process.md
+++ b/operational/community-review-process.md
@@ -24,7 +24,7 @@ The primary purpose of the OWASP Community Review (CR) is to systematically impr
 3. At such time as the Review Process will be begin, an email notification will be sent to all OWASP Members. 
 4. Only those who are OWASP Members are eligible to review and submit comments on the policy.
   - The review process is open for 21 days. No further comments will be accepted after the review period has closed.
-  - All comments should be specific edits and must be submitted through the approriate mailing list topic.
+  - All comments should be specific edits and must be submitted through the approriate mailing list topic (linked via the banner on the "Draft WIP" policy(ies)).
 5. Once the review period is closed all comments will be sent to the Policy Review Team (PRT):
   - OWASP Review Team has 30 days to review all comments.
   - Comments can either be:

--- a/operational/community-review-process.md
+++ b/operational/community-review-process.md
@@ -20,34 +20,33 @@ The primary purpose of the OWASP Community Review (CR) is to systematically impr
  
 ## Review/Approval Process
 1. The Community Review process is initiated when a new policy is needed, or an existing policy needs to be revised.
-2. Once the policy has been developed or revised and ready for review, it will be uploaded to https://owasp.org/www-policy/ and the title will be labeled with "(Draft WIP)"
+2. Once the policy has been developed or revised and ready for review, it will be uploaded to [https://owasp.org/www-policy/](https://owasp.org/www-policy/) and the title will be labeled with "(Draft WIP)".
 3. At such time as the Review Process will be begin, an email notification will be sent to all OWASP Members. 
 4. Only those who are OWASP Members are eligible to review and submit comments on the policy.
   - The review process is open for 21 days. No further comments will be accepted after the review period has closed.
   - All comments should be specific edits and must be submitted through the approriate mailing list topic.
-5. Once the review period is closed all comments will be sent to the Policy Review Team (PRT)
+5. Once the review period is closed all comments will be sent to the Policy Review Team (PRT):
   - OWASP Review Team has 30 days to review all comments.
   - Comments can either be:
     - Accepted: Means the PRT agreed exactly with the comment and change proposed by the commenter, which results in changes made to the policy. 
     - Revised: Means the PRT agrees with the comment (at least in part) and implements a change that is not exactly what the commenter proposed, still resulting in changes made to the policy.
     - Rejected: Means the PRT does not agree to make the change or cannot come to a consensus to make changes necessary to address the comment. A rational should be provided to explain why the comment is being rejected.
-    - Comments along with the comment resolution document will be posted to the website
+    - Comments along with the comment resolution document will be posted to the website.
 6. Once the comments have been reviewed and changes made to the policy based on comments that have been accepted or revised, the Policy Review Team votes to recommend to the OWASP Board the approval of the final document.
 7. Policy Review Team sends the policy and comment resolution document along with their recommendation for approval to the OWASP Board.
 8. The OWASP Board votes to approve the new or revised policy. If the board disapproves the policy, it is sent back along with the rational for the disapproval to the Policy Review Team of the policy for review and revision to policy. Then sent back to the board for approval. 
-9. Once approved, the policy is posted to the OWASP website having removed the "Draft WIP" label
+9. Once approved, the policy is posted to the OWASP website having removed the "Draft WIP" label.
 10. Notice via email will be provided to Members and Leaders of the new policy.
 
 ## Policy Review Team
 1. Comprised of seven members who are seated on January 1st of each calendar year.
-2. Membership is limited to Members and Membership must be maintained for continued service
-3. Membership of the Team includes
-  - One Project Leader from a Flagship Project, as invited in descending website traffic order
-  - One Chapter Leader from an active Chapter, as invited in descending website traffic order
-  - One Staff Member as assigned by the Executive Director
-  - Up to two not re-elected Board Members from the the previous election
+2. Membership is limited to Members and Membership must be maintained for continued service.
+3. Membership of the Team includes:
+  - One Project Leader from a Flagship Project, as invited in descending website traffic order.
+  - One Chapter Leader from an active Chapter, as invited in descending website traffic order.
+  - One Staff Member as assigned by the Executive Director.
+  - Up to two not re-elected Board Members from the the previous election.
   - As many Board Member nominees who were not elected from the previous election, as invited in descending voting order, to reach a total of seven members.
 4. Where members are invited, invitations are valid for seven days, will be made via email on or before December 1st, and will be revoked once expired.
 4. Should any Policy Review Team members be unable to complete their term, a like selected member will be invited. 
 5. Project and Chapter Leader members cannot serve consecutive year terms.
-


### PR DESCRIPTION
- Cosmetic changes for punctuation and linkifying.
- Minor content change to clarify mailing list contributions.

Note: https://owasp.org/www-policy/operational/conferences-events seems to have the feedback banner but isn't labelled as "Draft WIP"?