### PR TITLE
Membership Next Generation

### DIFF
--- a/operational/membership-rewards.md
+++ b/operational/membership-rewards.md
@@ -1,0 +1,104 @@
+# Membership Rewards
+
+The Membership Rewards program is open to all OWASP Members, and rewards mission aligned activities. 
+
+## Tiers
+
+There are three tiers with different levels of benefits:
+
+### Bronze (0-99 points)
+- OWASP member discounts to conferences and training
+- Access to discounts with our partners 
+- A vote in our elections
+- Ability to stand for the Global Board
+- Ability to stand for Committees
+- Laptop Sticker with OWASP Member <year>
+
+### Silver (100-500 points in a year)
+- All bronze benefits
+- free annual membership (replaces current honorary system)
+- Silver Pin with OWASP Member <year>
+
+### Gold (500 points in a year) 
+- All bronze and silver benefits
+- 1 complimentary training session at an OWASP conference of your choice
+- $50 discount on Lifetime membership
+- $100 discount on Global AppSec attendance 
+- Gold Pin with OWASP Member <year>
+
+### Platinum (2500 points in the last 5 years)
+- All Bronze, Gold, and Silver benefits
+- Nomination for a WASPY Award
+- Lifetime Honorary Membership
+- OWASP Lifetime Member Gold Pin
+
+## Earning points
+
+Points can be earned by:
+
+### Membership
+
+- Referring a new member who then joins (5 points)
+- Joining OWASP as a single year member (10 points)
+- Joining OWASP as a two year member (15 points)
+- Joining OWASP as a lifetime member (50 points)
+- Referring an OWASP $5k Corporate Member (25 points)
+- Referring an OWASP $15k Corporate Member (50 points)
+- Referring an OWASP $25k Corporate Member (100 points)
+
+### Fundraising
+
+- Setting up a monthly donation of more than $5 (30 points)
+- Setting up a monthly donation of more than $25 (50 points)
+- Donating up to $100 (1 point per $10)
+- Donating up to $1000 (10 points per $100 donation)
+- Donating over $1000 (150 points)
+- Referring a completed charitable gift or donation of up to $1000 (20 points)
+- Referring a completed charitable gift or donation of more than $5000 USD (50 points)
+
+### Sponsorship
+
+- Referring an OWASP Event sponsor (20 points)
+- Referring an OWASP Project Sponsor (20 points)
+- Referring an OWASP $25k Silver Corporate Sponsor (25 points)
+- Referring an OWASP $45k Gold Corporate Sponsor (45 points)
+- Referring an OWASP $80k Platinum Corporate Sponsor (80 points)
+- Referring an OWASP $120k Diamond Corporate Sponsor (120 points)
+
+### Events and Training
+
+- Paid attendance at a Regional, RegionalX, or AppSec Global event (25 points)
+- Paid attendance at a Regional, RegionalX, or AppSec Global training event (35 points)
+- Giving training at a Regional, RegionalX, or AppSec Global training event (50 points, 100 max per year)
+
+### Chapters
+
+- Attending a local chapter meeting (5 points, 60 max per year)
+- Speaking at a local chapter meeting (20 points, 100 max per year)
+
+More ideas TBA
+
+# Leadership Rewards Program
+
+The Leadership Awards program is open to all OWASP Leaders, including non-members. The objective of this program is that active leaders who achieve our mission deserve and should be rewarded with full membership for their volunteering, time, and effort. 
+
+If you are already a paid or lifetime member and don't wish to have complimentary membership, you will be bumped up one tier of the Membership Rewards program, to a maximum of 500 points per year (i.e. the maximum Gold membership tier), to obtain additional rewards. This is a huge bonus for those on the cusp of Gold membership or wanting to be recognized over a 5 year period. 
+
+## Mission Related Targets
+
+Each activity earns a number of points towards  Leadership Rewards, and once the Leader has earnt more than 100 Leader Points, they are eligible for complimentary full membership. There are many ways to achieve this number of points and we encourage overachieving for the benefit of our wider community and our members. 
+
+* Be a leader of a committee, project, or chapter, in the first 5 positions in leaders.md for more than six months in a row (Mandatory - 10 points)
+* The committee, project, or chapter must have updated all of its various sites (i.e. owasp.org, Meetup.com, GitHub.com) within the last three months (10 points)
+* A committee or chapter has met for the minimum amount required per their founding documents (5 points), discovered by updating minutes on the website or Meetup.
+* A committee or chapter has met at least 12 times in a year (20 points), discovered by updating minutes on the website or held events with attendees (Meetup).
+* The chapter has had at least 10 members renew or join within the last 12 months (10 points)
+* The committee, project, or chapter has obtained monetary donations or sponsorship in excess of $500 USD in the last 12 months made via the donations page on the owasp.org website and directed to them (20 points)
+* A project has made a release on GitHub within the last three years and updated the website to point to that release (5 points)
+* A project has made a release on GitHub within the last year and updated its website to point to that release (15 points)
+* A project has committed changes to code or wiki or accepted / merged / reviewed one or more pull requests within the last six months (10 points)
+* A project actively answered / resolved issues (5 points)
+* The leader has used Google Groups or Github Issues to answer questions from the community (10 points)
+* The leader is on the OWASP Community slack and has been active within the last three months (5 points)
+* The leader is on the OWASP Community slack and has been active over the last twelve months (10 points) 
+

--- a/operational/membership-rewards.md
+++ b/operational/membership-rewards.md
@@ -14,19 +14,19 @@ There are three tiers with different levels of benefits:
 - Ability to stand for Committees
 - Laptop Sticker with OWASP Member <year>
 
-### Silver (100-500 points in a year)
+### Silver (100-249 points in a year)
 - All bronze benefits
 - free annual membership (replaces current honorary system)
 - Silver Pin with OWASP Member <year>
 
-### Gold (500 points in a year) 
+### Gold (250-500 points in a year) 
 - All bronze and silver benefits
 - 1 complimentary training session at an OWASP conference of your choice
 - $50 discount on Lifetime membership
 - $100 discount on Global AppSec attendance 
 - Gold Pin with OWASP Member <year>
 
-### Platinum (2500 points in the last 5 years)
+### Platinum (2000 points in the last 5 years)
 - All Bronze, Gold, and Silver benefits
 - Nomination for a WASPY Award
 - Lifetime Honorary Membership
@@ -88,12 +88,50 @@ If you are already a paid or lifetime member and don't wish to have complimentar
 
 Each activity earns a number of points towards  Leadership Rewards, and once the Leader has earnt more than 100 Leader Points, they are eligible for complimentary full membership. There are many ways to achieve this number of points and we encourage overachieving for the benefit of our wider community and our members. 
 
+If a mission related target cannot be automatically measured with a simple number or date by an API call, it must not be included.
+
+If a Chapter, Project, or Committee chooses to not use OWASP systems or monitored APIs, they are not eligible for the Leadership Rewards Program. 
+
+## Leader Points
+
 * Be a leader of a committee, project, or chapter, in the first 5 positions in leaders.md for more than six months in a row (Mandatory - 10 points)
 * The committee, project, or chapter must have updated all of its various sites (i.e. owasp.org, Meetup.com, GitHub.com) within the last three months (10 points)
+
+## Fundraising and donations
+
+* The committee, project, or chapter has obtained monetary donations or sponsorship in excess of $500 USD in the last 12 months made via the donations page on the owasp.org website and directed to them (20 points)
+
+## Membership Points
+
+* The project, committee, or chapter has had at least 10 members renew or join within the last 12 months (1 point per member, once 10 has been reached)
+* An event was able to sell more than 10 full paid memberships (1 point per paid member after 10 members)
+
+## Chapter and Committee Points
+
 * A committee or chapter has met for the minimum amount required per their founding documents (5 points), discovered by updating minutes on the website or Meetup.
 * A committee or chapter has met at least 12 times in a year (20 points), discovered by updating minutes on the website or held events with attendees (Meetup).
-* The chapter has had at least 10 members renew or join within the last 12 months (10 points)
-* The committee, project, or chapter has obtained monetary donations or sponsorship in excess of $500 USD in the last 12 months made via the donations page on the owasp.org website and directed to them (20 points)
+
+## Events Points
+
+* An event registration has been accepted (5 points)
+* An event organizing committee maintains a schedule of activites with current status on the owasp.org or defined event platform (10 points)
+* An official event budget has been accepted (5 points)
+* The event expenses came in under budget (15 points)
+* The event profit exceeded the budgeted profit (15 points) 
+* The event obtained sponsorship in excess of its expenses (15 points)
+* A local event of up to 100 people was run (10 points)
+* Participation on the call for papers / training committee (25 points)
+* A regional event of up to 150 people was run (25 points)
+* A regional event of up to 500 people was run (50 points)
+* A regional event of over 500 attendeees was run (100 points) 
+* A local chapter volunteered for a AppSec Global event (1 point per hour of organizing committee member or volunteer time, with a 50 point minimum if no records are kept)
+
+## Project Points
+
+* A project page is hosted and maintained in the owasp.org website or as a sub-domain (i.e. project.owasp.org) 15 points
+* The project pages get between 0 and 50,000 hits per year (5 points)
+* The project pages get between 50k and a million hits per year (10 points)
+* The project pages gets more than a million hits per year (25 points)
 * A project has made a release on GitHub within the last three years and updated the website to point to that release (5 points)
 * A project has made a release on GitHub within the last year and updated its website to point to that release (15 points)
 * A project has committed changes to code or wiki or accepted / merged / reviewed one or more pull requests within the last six months (10 points)
@@ -101,4 +139,6 @@ Each activity earns a number of points towards  Leadership Rewards, and once the
 * The leader has used Google Groups or Github Issues to answer questions from the community (10 points)
 * The leader is on the OWASP Community slack and has been active within the last three months (5 points)
 * The leader is on the OWASP Community slack and has been active over the last twelve months (10 points) 
-
+* The project graduated from incubator to lab (15 points)
+* The project graduated from lab to Flagship (25 points)
+* A lab or flagship project maintained its current status (15 points)


### PR DESCRIPTION
This PR is to develop the next generation of membership programs. It's not adopted nor is it official. Please don't assume this is policy until approved. 

This is root and branch reform of our membership model. I want to introduce OWASP Reward Points, that through actively doing automatically measurable KPIs, members and leaders can earn complimentary membership and other rewards by doing the things that advance our mission. I would like to see that active project, chapter and committee leaders are able to be rewarded for their hard work, but in return, we can measure their success. This will replace Honorary Membership and meet community expectations regarding "free" leader membership, which has been a huge source of contention. Just like a coffee card, we will need to balance this approach to ensure that the activities contain a wide varieties of earning points that also brings activity and funds to the Foundation. 