### PR TITLE
Finance Reform - Awards and Scholarships

### DIFF
--- a/operational/awards-and-scholarships.md
+++ b/operational/awards-and-scholarships.md
@@ -22,15 +22,17 @@ This policy encourages our community to establish awards or prizes for OWASP com
 ## Overview of Awards, Scholarships, and Travel Assistance process
 
 Any OWASP Leader, OWASP Foundation, or OWASP Board (hereon: organizers) can establish an award, prize, or scholarship and any associated travel assistance. 
+
 Organizers should:
 
 1.	Review relevant [Awards and Scholarships Guidance](TBA)
-2.	Plan the award or scholarship, and seek potential funding sources if required
+2.	Plan the award or scholarship application, and seek potential funding sources if required
 3.	Submit a request at https://contact.owasp.org
 
 The OWASP Executive Director and any relevant committee shall evaluate the proposal and decide on approval within 30 days, taking into account published temporary restrictions or travel restrictions imposed by relevant authorities. If the request requires a Board vote or exemption, a decision will occur within 60 days to allow for a Committee and subsequent Board meeting.
 
 If approved, the organizers shall:
+
 - Publicize the award or scholarship, finalize donors, sponsorships or fundraise necessary funds, and open the award or scholarship to entrants no later than 30 days before the deadline
 - Score and select the winner using the selection rubric within seven days of the announced deadline
 - Publish the selection result on the owasp.org website and award the prize or scholarship within 30 days of the announced deadline
@@ -55,11 +57,12 @@ Travel assistance must comply with the [travel policy](TBA) and the [expense pol
 
 Organizers should name the award or scholarships to include OWASP within the name, consistent with the OWASP branding guidelines. Examples might include: "OWASP Lifetime Achievement Award," "OWASP Ottawa CTF Champion," "OWASP AppSec Manchester Scholarship," and so on. 
 
-Award names that are confusing with existing Foundation awards may not be approved.
+Award names that are confusing with existing OWASP trademarks, awards, or scholarships may not be approved.
 
 ### Funding
 
 Funding for awards, scholarships, and travel assistance should be fully funded, including by:
+
 - Individual or corporate donations, sponsorships, or fundraising
 - Chapters, projects, events, or committees using local donations, sponsorships, or fundraising
 - An approved grant under the [Grants policy](TBA)
@@ -73,7 +76,8 @@ All sponsorships, fundraising, and donations are subject to standard OWASP polic
 Award or Scholarship proposals are more likely to be approved if selection criteria include equity for disadvantaged, underrepresented, or underserved groups. Awards should be directed towards genuinely long term or meritorious service to OWASP and our mission, or as an encouragement to new projects, chapters, initiatives, or as a reward for OWASP competitions that fulfill our mission. 
 
 After approval, organizers must publish the selection criteria on the OWASP website for public transparency. Organizers should coordinate with the Foundation to ensure that all nominees or entrants are eligible per the selection criteria.
-Organizers must publish the awarded accolade results on the OWASP website, including the selection rubric and scores, and are encouraged to promote the accolade. As privacy permits, organizers should publish recipients' names (with their permission) to allow members, donors, and the public to determine that the prize was transparently and fairly selected. Organizers must make recipients' details available to the OWASP Foundation to process the award, scholarship, or travel assistance. 
+
+Organizers must publish results on the OWASP website, including the selection rubric and scores, and are encouraged to promote the accolade. As privacy permits, organizers should publish recipients' names (with their permission) to allow members, donors, and the public to determine that the prize was transparently and fairly selected. Organizers must make recipients' details available to the OWASP Foundation to process the award, scholarship, or travel assistance. 
 
 ## Transparency, Integrity, and Oversight
 
@@ -90,11 +94,13 @@ All prizes are subject to being audited by the OWASP Foundation, including valid
 Awards, scholarships, and travel assistance are not transferable, cannot be passed on, or resold to others. If organizers cannot reach a recipient within 30 days to claim their prize, or the recipient declines the prize, organizers shall choose the subsequent highest scoring winner.
 
 ### Exemptions to policy
+
 Exemptions to this policy can be granted by the OWASP Executive Director and documented in the application. Exemptions requiring funding exceeding $1000 require an affirmative Board vote. 
 
 ### Conflicts of Interest
 
 To prevent perceived or actual conflicts of interest, if an award or scholarship is potentially open to: 
+
 - Organizers who created or assisted with the submission or selection criteria
 - Members of the selection panel 
 - Involved chapter, project, or event leaders, or relevant committee members

--- a/operational/awards-and-scholarships.md
+++ b/operational/awards-and-scholarships.md
@@ -13,7 +13,7 @@ notice: 2021-02-28
 
 Draft for comment.
 
-# Awards and Scholarships Policy
+# {{ page.title }}
 
 ## Background
 

--- a/operational/awards-and-scholarships.md
+++ b/operational/awards-and-scholarships.md
@@ -1,12 +1,15 @@
 ---
 
-title: Expense Policy
+title: Awards and Scholarships Policy
 layout: col-document
 document: Rules of Procedure
 tags: Rules of Procedure
-notice: 2020-08-12
+notice: 2021-02-28
 
 ---
+
+{% capture date-to-pass %}{{ page.notice }}{% endcapture %}
+{% include policy-feedback.html start-date=date-to-pass %}
 
 Draft for comment.
 

--- a/operational/awards-and-scholarships.md
+++ b/operational/awards-and-scholarships.md
@@ -25,9 +25,9 @@ Any OWASP Leader, OWASP Foundation, or OWASP Board (hereon: organizers) can esta
 
 Organizers should:
 
-1.	Review relevant [Awards and Scholarships Guidance](TBA)
-2.	Plan the award or scholarship application, and seek potential funding sources if required
-3.	Submit a request at https://contact.owasp.org
+1. Review relevant [Awards and Scholarships Guidance](TBA)
+2. Plan the award or scholarship application, and seek potential funding sources if required
+3. [Submit a request](https://contact.owasp.org)
 
 The OWASP Executive Director and any relevant committee shall evaluate the proposal and decide on approval within 30 days, taking into account published temporary restrictions or travel restrictions imposed by relevant authorities. If the request requires a Board vote or exemption, a decision will occur within 60 days to allow for a Committee and subsequent Board meeting.
 
@@ -51,7 +51,7 @@ Trainers are encouraged, but not required, to waive their training fee for schol
 
 Scholarships assisting under-served or under-represented communities may offer travel assistance to OWASP events, with a preference to serve local and regional events over costly international travel. Travel assistance can only be provided as part of a scholarship and should be on an as needs basis.
 
-Travel assistance must comply with the [travel policy](TBA) and the [expense policy](TBA).
+Travel assistance must comply with the [travel policy](TBA) and the [expense policy](/www-policy/operational/expense-reimbursement).
 
 ### Naming
 
@@ -99,7 +99,7 @@ Exemptions to this policy can be granted by the OWASP Executive Director and doc
 
 ### Conflicts of Interest
 
-To prevent perceived or actual conflicts of interest, if an award or scholarship is potentially open to: 
+Awards and scholarships are subject to the [Conflict of Interest Policy](/www-policy/operational/conflict-of-interest). To prevent perceived or actual conflicts of interest, if an award or scholarship is potentially open to: 
 
 - Organizers who created or assisted with the submission or selection criteria
 - Members of the selection panel 

--- a/operational/awards-and-scholarships.md
+++ b/operational/awards-and-scholarships.md
@@ -1,6 +1,6 @@
 ---
 
-title: Awards and Scholarships Policy
+title: Awards and Scholarships Policy (WIP - draft)
 layout: col-document
 document: Rules of Procedure
 tags: Rules of Procedure

--- a/operational/awards-and-scholarships.md
+++ b/operational/awards-and-scholarships.md
@@ -1,0 +1,110 @@
+---
+
+title: Expense Policy
+layout: col-document
+document: Rules of Procedure
+tags: Rules of Procedure
+notice: 2020-08-12
+
+---
+
+Draft for comment.
+
+# Awards and Scholarships Policy
+
+## Background
+
+This policy encourages our community to establish awards or prizes for OWASP competitions and scholarships and travel assistance for OWASP events. Awards recognize high impact members, chapters, initiatives, projects, or as prizes for OWASP competitions. Scholarships fulfill our mission to underserved and disadvantaged communities and individuals, improving equity and access for those who need assistance. This policy creates financially responsible funding mechanisms, published eligibility and selection criteria, and a consistent and transparent process to award prizes or recipients. 
+
+## Overview of Awards, Scholarships, and Travel Assistance process
+
+Any OWASP Leader, OWASP Foundation, or OWASP Board (hereon: organizers) can establish an award, prize, or scholarship and any associated travel assistance. 
+Organizers should:
+
+1.	Review relevant [Awards and Scholarships Guidance](TBA)
+2.	Plan the award or scholarship, and seek potential funding sources if required
+3.	Submit a request at https://contact.owasp.org
+
+The OWASP Executive Director and any relevant committee shall evaluate the proposal and decide on approval within 30 days, taking into account published temporary restrictions or travel restrictions imposed by relevant authorities. If the request requires a Board vote or exemption, a decision will occur within 60 days to allow for a Committee and subsequent Board meeting.
+
+If approved, the organizers shall:
+- Publicize the award or scholarship, finalize donors, sponsorships or fundraise necessary funds, and open the award or scholarship to entrants no later than 30 days before the deadline
+- Score and select the winner using the selection rubric within seven days of the announced deadline
+- Publish the selection result on the owasp.org website and award the prize or scholarship within 30 days of the announced deadline
+
+### Awards
+
+Organizers can create awards to recognize high impact contributions towards OWASP's mission or prizes for competitions. Awards cannot offer memberships, donations to other organizations, or cash prizes to individuals. In many countries, raffles, games of chance, and so on may be regulated. Organizers are responsible for ensuring a competition with a prize has appropriate permits or legal within their jurisdiction.
+
+### Scholarships
+
+Scholarships waive registration or attendance fees to paid OWASP events, activities, or training. Scholarships should not exceed 20% of all paid attendees in any class, event, or activity. Scholarships should be either zero cost to the event or fully funded before approval. 
+
+Trainers are encouraged, but not required, to waive their training fee for scholarships. If a trainer does not waive their fee, organizers must secure sponsorship or funding to cover the expense. Trainers may limit the number of scholarships. 
+
+### Travel Assistance
+
+Scholarships assisting under-served or under-represented communities may offer travel assistance to OWASP events, with a preference to serve local and regional events over costly international travel. Travel assistance can only be provided as part of a scholarship and should be on an as needs basis.
+
+Travel assistance must comply with the [travel policy](TBA) and the [expense policy](TBA).
+
+### Naming
+
+Organizers should name the award or scholarships to include OWASP within the name, consistent with the OWASP branding guidelines. Examples might include: "OWASP Lifetime Achievement Award," "OWASP Ottawa CTF Champion," "OWASP AppSec Manchester Scholarship," and so on. 
+
+Award names that are confusing with existing Foundation awards may not be approved.
+
+### Funding
+
+Funding for awards, scholarships, and travel assistance should be fully funded, including by:
+- Individual or corporate donations, sponsorships, or fundraising
+- Chapters, projects, events, or committees using local donations, sponsorships, or fundraising
+- An approved grant under the [Grants policy](TBA)
+- An approved annual Foundation budget line item
+- An affirmative Board vote
+
+All sponsorships, fundraising, and donations are subject to standard OWASP policies, procedures, and associated administration fees.
+
+### Transparent selection criteria, processes, and approvals
+
+Award or Scholarship proposals are more likely to be approved if selection criteria include equity for disadvantaged, underrepresented, or underserved groups. Awards should be directed towards genuinely long term or meritorious service to OWASP and our mission, or as an encouragement to new projects, chapters, initiatives, or as a reward for OWASP competitions that fulfill our mission. 
+
+After approval, organizers must publish the selection criteria on the OWASP website for public transparency. Organizers should coordinate with the Foundation to ensure that all nominees or entrants are eligible per the selection criteria.
+Organizers must publish the awarded accolade results on the OWASP website, including the selection rubric and scores, and are encouraged to promote the accolade. As privacy permits, organizers should publish recipients' names (with their permission) to allow members, donors, and the public to determine that the prize was transparently and fairly selected. Organizers must make recipients' details available to the OWASP Foundation to process the award, scholarship, or travel assistance. 
+
+## Transparency, Integrity, and Oversight
+
+### Oversight
+
+The OWASP Executive Director shall report to the OWASP Board quarterly on all Awards, Scholarships, and Travel Assistance awarded and received, along with improvements to this policy. 
+
+### Audit authority
+
+All prizes are subject to being audited by the OWASP Foundation, including validating those selection criteria were followed, recipients received their award, scholarships, or travel assistance. 
+
+### Non-transferability
+
+Awards, scholarships, and travel assistance are not transferable, cannot be passed on, or resold to others. If organizers cannot reach a recipient within 30 days to claim their prize, or the recipient declines the prize, organizers shall choose the subsequent highest scoring winner.
+
+### Exemptions to policy
+Exemptions to this policy can be granted by the OWASP Executive Director and documented in the application. Exemptions requiring funding exceeding $1000 require an affirmative Board vote. 
+
+### Conflicts of Interest
+
+To prevent perceived or actual conflicts of interest, if an award or scholarship is potentially open to: 
+- Organizers who created or assisted with the submission or selection criteria
+- Members of the selection panel 
+- Involved chapter, project, or event leaders, or relevant committee members
+- Foundation staff or Board members
+
+an [ethical barrier](TBA) is required, such as recusal from decision making. Ethical barriers will be reviewed and approved by the Executive Director during the application process. 
+
+Organizers must report applicable ethical barriers used in deciding the award or scholarship. 
+
+### Appeal or Dispute Resolution
+
+The relevant committee is the first point of contact for any disputes, followed by the Compliance Committee or OWASP Whistleblower process, the OWASP Executive Director, and the OWASP Board. 
+
+### Sanctions
+
+Abuse of this policy may be grounds for not being able to award future prizes or scholarships. In severe cases, as determined by the Executive Director, sanctions could include revocation of OWASP membership, loss of leadership, or referral to law enforcement authorities.


### PR DESCRIPTION
This policy encourages our community to establish awards or prizes for OWASP competitions and scholarships and travel assistance for OWASP events. Awards recognize high impact members, chapters, initiatives, projects, or as prizes for OWASP competitions. Scholarships fulfill our mission to underserved and disadvantaged communities and individuals, improving equity and access for those who need assistance. This policy creates financially responsible funding mechanisms, published eligibility and selection criteria, and a consistent and transparent process to award prizes or recipients. 