### PR TITLE
Finance Reform - Grants 

### DIFF
--- a/operational/grants.md
+++ b/operational/grants.md
@@ -1,0 +1,151 @@
+---
+
+title: Grant Policy (Draft - WIP)
+layout: col-document
+document: Rules of Procedure
+tags: Rules of Procedure
+notice: 2021-02-28
+
+---
+
+{% capture date-to-pass %}{{ page.notice }}{% endcapture %}
+{% include policy-feedback.html start-date=date-to-pass %}
+
+## {{page.title}
+
+Grants help fulfill our mission to improve the security of software globally. Any OWASP Member, Chapter, Project, Committee, or Event may create grants for mission-related activities or deliverables, including sabbaticals. This policy creates financially responsible funding mechanisms and a consistent and transparent process to approve, fund, and deliver grant outcomes.
+
+## Overview of the grant process
+
+Ideas for grants can come from both within OWASP and from the larger community. 
+
+Grant applicants should:
+
+1.	Plan and document a deliverable or package of milestones and deliverables that are specific, realistic, and time-bound
+2.	Seek funding or sponsorship to fund the grant
+3.	[Submit a grant request](TBA)
+
+The OWASP Projects and Technology Director and any relevant committee will evaluate the grant proposal and decide on approval within 30 days, considering the budget and any published temporary restrictions. If the request requires an exemption or Board vote, a decision will occur within 60 days to allow for a Committee and subsequent Board meeting.
+
+If approved, grant applicants shall:
+
+- Publish the grant on their OWASP.org web page, including the grant acknowledgment
+- Finalize donors, sponsorships, or fundraise necessary funds no later than seven days after grant approval. 
+- Work on and deliver the deliverable, milestone, or package of milestones to a place that fulfills the obligations of applicable open-source licenses, such as on OWASP’s GitHub
+
+Upon completing a milestone or deliverable, the OWASP Projects and Technology Director will guide a quality and completion review process, including relevant committees and sponsors. If all reviewing parties agree that the deliverable or milestone has been delivered, OWASP will process payment for the current milestone or deliverable within 30 days.
+
+## Grant Governance
+
+Spending on mission is required, with verifiable and timely outcomes. Grants must be approved before committing the OWASP Foundation to any contracts or costs associated with the grant. The OWASP Foundation has sole signing authority for any contracts or obligations.
+
+### Budgeting 
+
+Grants should detail all likely expenses in the application process. Budgets should comply with all Foundation policy concerning expenses, capital purchases, operational expenses, signing authority, and travel. Any upfront costs must be detailed in the application and budget and why they must be paid upfront. 
+
+Expenses greater than the approved budget will not be paid. Expenses above the approved budget are at the OWASP Project and Technology Director’s discretion. Expenses greater than the Executive Director’s signing authority requires an OWASP Board affirmative vote. 
+
+### Sabbatical stipends
+
+Grants can be used to fund a sabbatical stipend to benefit one or more project or initiative members to achieve a specific goal over some time. These sabbatical grants should be time-limited to between 1 and 12 months in duration and provide a list of deliverables/outcomes. 
+
+Sabbatical stipends do not form an employment contract with the OWASP Foundation.
+
+### Grant duration
+
+Grants must not exceed 12 months duration. 
+
+Grants or sabbaticals of greater duration than 30 days should consist of multiple milestones, with clearly defined deliverables that permit milestone payments. 
+
+### Research and other high-risk grants
+
+OWASP encourages and funds high-quality research, but this comes with risks. Grants funding research, where the outcome or deliverable is not yet known, or any risky activity, such as promising a significant deliverable for a small sum, should document how the grant participants will manage the risk, such as milestone payments or similar.
+
+Under no circumstances will the OWASP Foundation be liable to deliver on the grant if the original applicants cannot achieve the agreed deliverable in a timely fashion. 
+
+### Restricted spending
+
+There are few restrictions on grant spending. However, approval of grants containing any of the following items likely result in negotiations or a rejected application:
+
+- Temporary expense restrictions in effect at the time of the grant application
+- Capital and operational expenses must be necessary to complete the grant 
+- Travel must be essential to complete the grant but is generally discouraged
+- Cash, salary, or contractual payments to grant applicants or other recipients (see stipends)
+- Ongoing office space or co-working space costs
+- Payments for dedicated shared services already provided by the OWASP Foundation
+- OWASP Memberships, contributions, memberships, or payments to other organizations 
+
+If a restriction is approved, it must follow the relevant OWASP policy to ensure adequate governance and safeguards. 
+
+### Termination for cause
+
+After 60 days, the OWASP Foundation can terminate a grant due to a lack of communication, limited or no activity, or missing or inadequate delivery of agreed milestones. 
+
+Grant applicants with one or more terminated grants may only be paid on a “payment on completion” basis. Applicants with more than three terminated grants may not apply for grants for five years.
+
+Under no circumstances will the OWASP Foundation be liable to deliver on terminated grants if the original applicants cannot achieve the deliverable in a timely fashion. 
+
+## Grant Financial Controls
+
+### Funding
+
+Grants should be fully funded, including by:
+
+- Individual or corporate donations, sponsorships, or fundraising
+- Chapters, projects, events, or committees using local contributions, support, or fundraising
+- OWASP Grant Fund, which is funded annually by the OWASP Board 
+- An affirmative Board vote to fund a strategic grant
+
+All sponsorships, fundraising, and donations are subject to standard OWASP policies, procedures, and associated administration fees.
+
+### Grant acknowledgment for compliance audits
+
+OWASP has entities in the United States and the European Union, and we must comply with non-profit regulations. All grants must be discoverable in the case of non-profit compliance audits. An acknowledgment of funding sources must be on the grant recipients OWASP.org page and in any documents, “About…” dialogs, or help pages of OWASP projects funded by a grant. 
+
+If OWASP supported the work through the OWASP Grants Fund, the acknowledgment must be of the form:
+
+```“This work was supported by funding from OWASP grant <grantID> from the OWASP Foundation.”```
+
+If one or more donations or sponsorships supported the work, the acknowledgment must be of the form:
+
+```“This work was supported by funding from OWASP Grant <grantID> from <sponsor> <, sponsor><, and the OWASP Foundation.”```
+
+### Unspent funds
+
+Unspent funds fail to meet OWASP’s, sponsors’ and donors’ expectations, and tax compliance requirements. 
+
+Within 60 days of completion or termination of a grant, the following applies:
+
+-	Unused funds will revert to the OWASP Grants Fund 
+-	Foundation-sponsored terminated grants will return the entire residual grant to the grants pool
+-	Donation or sponsored terminated grants will return the residual portion of sponsorships and donations, minus an administration fee to the sponsor or donor
+
+### Non-transferability
+
+Grants are not transferable, cannot be passed on, or resold to others. Grants can seek additional volunteers to help complete the grant and share the grant with the volunteers.
+
+## Transparency, Integrity, and Oversight
+
+### Oversight
+
+The OWASP Executive Director shall report to the OWASP Board quarterly on all grants awarded and delivered, along with improvements to this policy. 
+
+### Audit authority
+
+Grants are subject to being audited by the OWASP Foundation, including validating grant selection criteria was followed, completed satisfactorily and on time, ensuring budgets were spent in accordance with policy, and obtaining any sponsoring organization’s views. 
+
+### Exemptions to policy
+
+Exemptions to this policy can be granted by the OWASP Executive Director and documented in the application. Exemptions requiring changes to our bylaws, policies, or non-compliant funding exceeding the Executive Director’s [signing authority](/www-policy/operational/signatory2.md), require an affirmative Board vote. 
+
+### Conflicts of Interest
+
+Grants are subject to the [Conflict of Interest Policy](/www-policy/operational/conflict-of-interest). 
+
+### Appeal or Dispute Resolution
+
+The relevant committee is the first point of contact for any disputes, followed by the Compliance Committee or OWASP Whistleblower process, the OWASP Executive Director, and the OWASP Board. 
+
+### Sanctions
+
+Grant recipients who abuse the grant process may not participate in or receive future grants. In severe cases, as determined by the Executive Director, sanctions could include revocation of OWASP membership, loss of leadership, or referral to law enforcement authorities.


### PR DESCRIPTION
Grants help fulfill our mission to improve the security of software globally. Any OWASP Member, Chapter, Project, Committee, or Event may create grants for mission-related activities or deliverables, including sabbaticals. This policy creates financially responsible funding mechanisms and a consistent and transparent process to approve, fund, and deliver grant outcomes.