### PR TITLE
Chapter Committee Regional Chapter Policy Update

### DIFF
--- a/operational/chapters.md
+++ b/operational/chapters.md
@@ -12,7 +12,7 @@ DRAFT Regional chapter PROPOSAL. This document is not policy.
 
 ## Overview
 
-Chapters are central to OWASP's mission of achieving community around the world. This policy defines the rules related to starting, running, maintaining, and dissolving OWASP chapters.
+Chapters are central to OWASP's mission of building a community of appsec professionals and developers around the world. This policy defines various chapter types, starting, running, maintaining, and dissolving OWASP chapters.
 
 ## Running a Chapter
 
@@ -21,18 +21,20 @@ Chapters are central to OWASP's mission of achieving community around the world.
 Chapters must be discoverable by new and existing members and participants.
 
 - Chapter activities must appear on the owasp.org website.
-- It is strongly recommended to use OWASP's official chapter and event scheduling platform. The Foundation pays event platform fees for active chapters.
-- If you use the Foundation's scheduling service, your Chapter's group account must be defined under the OWASP Foundation account. Using the OWASP Foundation's scheduling service provides continuity for chapter members if chapter leadership becomes inactive.
+- Chapter leaders should use OWASP's official chapter and event scheduling platform. The OWASP Foundation pays event platform fees for active chapters.
+- If you use the OWASP Foundation's scheduling service, your Chapter's group account must be defined under the OWASP Foundation account. Using the OWASP Foundation's scheduling service provides continuity for chapter members if chapter leadership becomes inactive.
 - If you do not use OWASP's official event platform, you must mirror your events (whether automatically or manually) to your chapter page on the owasp.org website. The OWASP Foundation is not obliged to reimburse alternate meeting scheduling services expenses.
 - Each chapter is responsible for creating and maintaining their owasp.org chapter home page (see also [Starting a New Chapter](#starting-a-new-chapter) and [Meetings and Activity Requirements](#meetings-and-activity-requirements)).
 - A list of the current leaders and email addresses must be listed on the Chapter's web page on owasp.org. Leaders are strongly encouraged to use their @owasp.org email address on their chapter pages.
 
 ### Meetings and Activity Requirements
 
-- Attendees do not need to be members. All members of the public are allowed to attend OWASP meetings. However, chapter leaders may organize reasonably restricted chapter events and activities in addition to regular meetings.
-- Chapter meetings must be free.
-- Chapters should host a minimum of 3 chapter activities a year to maintain an active OWASP chapter. The activity can be in person, virtual, or an [approved OWASP event](https://owasp.org/www-policy/operational/events) run by the OWASP chapter (or in collaboration with another chapter or external organization with the approval of the Foundation).
-- Chapter activities are for the benefit of the community and could include, but are not limited to:
+- Attendees do not need to be members. All members of the public are allowed to attend OWASP meetings. However, chapter leaders may organize restricted chapter events and activities in addition to regular meetings.
+- Chapter meetings must be free to attend, both in monetary and access terms
+- Chapters should host a minimum of 3 chapter activities a year to maintain an active OWASP chapter. The activity can be in person, virtual, or an [approved OWASP event](https://owasp.org/www-policy/operational/events) run by the OWASP chapter (or in collaboration with another chapter or external organization with the approval of the OWASP Foundation).
+
+Chapter activities are for the benefit of the community and could include, but are not limited to:
+
 - Chapter meetings (traditional meetups)
 - Training days
 - Capture the Flag/Hack-a-Thon events
@@ -40,13 +42,13 @@ Chapters must be discoverable by new and existing members and participants.
 - Student-focused activities, at secondary or college level
 - Chapter leaders must post chapter activity information (date, time, and location) on the owasp.org chapter page before the event start date.
 
-For chapters using OWASP Meetup Pro, mirroring meetings automatically is simple and easy. Add the following code to make your life a lot easier. In the header, please make sure the `meetup-group` parameter exists and is accurate:
+For chapters using OWASP Meetup Pro, mirroring meetings automatically is simple and easy. Chapter leaders should add the following code to minimize the amount of manual work required. In the header, please make sure the `meetup-group` parameter exists and is accurate:
 
 ```javascript
 meetup-group: your-meetup-group
 ```
 
-If the meetup-group header is identical to your OWASP Meetup Pro Group name (e.g. `meetup-group: OWASP-Colorado-Springs-Meetup`), the code will automatically mirror your upcoming meeting information as mandated by the policy above.
+The above code will automatically mirror your upcoming meeting information if the meetup-group header is identical to your OWASP Meetup Pro Group name. e.g., `meetup-group: OWASP-Colorado-Springs-Meetup`
 
 Add this line to where you would like your upcoming meetings to appear in the body automatically:
 
@@ -56,19 +58,19 @@ Add this line to where you would like your upcoming meetings to appear in the bo
 
 (Remove the space between `{` and `%` to make this work on your page)
 
-NB: Per the policy above, if you don't use this, or it's set up incorrectly, you will need to do this step manually. Once an event is complete, please add it to the past events tab. For a more detailed example, see [https://owasp.org/www-projectchapter-example/]
+NB: Per the policy above, if you misconfigure or do not use the above automation, you will need to do this step manually. Once your event is complete, please add it to the past events tab. For a more detailed example, see [https://owasp.org/www-projectchapter-example/]
 
 #### Student chapter Activity Requirements
 
 Student chapters must adhere to the City chapter activity requirements.
 
-As many tertiary institutions have extensive time off between academic years or semesters, leaders should plan to meet activity requirements within each semester, as activity is measured over the previous 12 months.
+As tertiary institutions often have significant vacations between academic years or semesters, student chapter leaders should plan to meet activity requirements within each semester.
 
 #### Regional chapter Activity Requirements
 
 Regional chapters must meet the following activity requirements:
 
-- EITHER a minimum of THREE (3) activities per year in addition to a larger event under the events policy, e.g., AppSec Day jointly run by all participating branches or Chapters;
+- EITHER a minimum of THREE (3) activities per year in addition to a significant event under the events policy, e.g., an AppSec Day jointly run by all participating branches or Chapters;
 - OR a minimum of SIX (6) activities per year, including all branch activities.
 
 Regional branch activities count towards Regional chapter activity requirements. Activities organized by participating City chapters do not count towards Regional chapter activity requirements.
@@ -77,23 +79,23 @@ Regional branch activities count towards Regional chapter activity requirements.
 
 A Branch must host a minimum of one activity per year but should strive for more.
 
-A Branch that is not meeting its minimum requirements should be reactivated by the Regional chapter Leaders if possible, including nominating a new Branch Organizer. If they are not successful in reactivating the Branch and the Branch continues to fail its requirements, the Regional chapter Leaders must deactivate and even remove the Branch as necessary. This will be monitored yearly by the Chapters Committee.
+A Branch that is not meeting its minimum requirements should be reactivated by the Regional chapter Leaders if possible, including nominating a new Branch Organizer. Regional chapter Leaders must deactivate and remove the Branch if the branch organizers do not meet branch activity requirements. Branch activity compliance will be monitored yearly by the Chapters Committee.
 
 ### Communication
 
 OWASP is a social community, and we need to communicate with our community regularly.
 
 - Chapter leaders should use their owasp.org email address for all OWASP related correspondence.
-Chapter leaders should regularly monitor their owasp.org email address and respond within nine business days.
-- Requests from OWASP staff, such as expense claims, should be responded to by one or more chapter leaders within nine business days.
+- Chapter leaders should regularly monitor their owasp.org email address and respond within nine business days.
+- Requests from the OWASP Foundation, such as expense claims, should be responded to by one or more chapter leaders within nine business days.
 - Leaders are encouraged, but not required, to monitor and participate in the [OWASP Leaders List](https://groups.google.com/u/1/a/owasp.org/g/leaders), other Google groups, and the Slack platform.
-- OWASP chapters can create and manage their own social media presence and other reasonable communication channels. Chapter leaders must share access to these accounts with all Chapter leaders. The account administration should be handed over to a remaining chapter leader when stepping down.
+- OWASP chapters can create and manage their own social media presence and other reasonable communication channels. Chapter leaders must share access to these accounts with all Chapter leaders. When a Chapter Leader steps down, the Chapter Leader should hand over the account administration to a remaining chapter leader.
 
-We recommend that chapter leaders set an [out of office notification](https://support.google.com/mail/answer/25922?co=GENIE.Platform%3DDesktop&hl=en) within their @owasp.org email if they are planning to take leave, so that the chapter members, the Chapter Committee, and Foundation staff are aware of any absences or delays in responding to communications.
+If Chapter Leaders plan to take leave, please set an [out of office notification](https://support.google.com/mail/answer/25922?co=GENIE.Platform%3DDesktop&hl=en) on your owasp.org email to inform chapter members, the Chapter Committee, and the OWASP Foundation of the potential for delays in responding.
 
 ## Shared Services
 
-OWASP Foundation will provide chapters with the following shared services at no cost. Chapters are encouraged to use these. Chapter leaders can access these services by submitting a ticket via [Contact Us](https://contact.owasp.org/). If, after nine business days have passed, and reasonable efforts have been made to attempt to utilize shared services, no response is received, the Chapter may, with due care, seek a reasonable alternative, filling out a [Chapter Funding Pre-Approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107) ticket.
+OWASP Foundation will provide chapters with the following shared services at no cost. Chapters are encouraged to use these. Chapter leaders can access these services by submitting a ticket via [Contact Us](https://contact.owasp.org/).
 
 - Chapter page on the owasp.org website.
 - A chapter scheduling service for meetings and local events with RSVP functionality and hidden video conference details.
@@ -103,69 +105,70 @@ OWASP Foundation will provide chapters with the following shared services at no 
 - Assistance and resources are available through the [Chapter Committee](https://owasp.org/www-committee-chapter/) and other [OWASP Committees](https://owasp.org/committees/).
 - Event insurance covering chapter meetings.
 
-Services identical or like those provided by the Foundation cannot be expensed without [prior approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107). Where possible, all chapters are encouraged to use a service that respects user privacy.
+Chapter leaders cannot expense services identical or similar to those provided by the OWASP Foundation without [prior approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107). Where possible, all chapters are encouraged to use a service that respects user privacy.
+
+The Chapter may seek a reasonable alternative to OWASP Foundation shared services only if there is no response after nine business days. Chapter leaders can do this by filling out a [Chapter Funding Pre-Approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107) ticket.
 
 ### Shared Services for Regional Branches
 
-Shared services provided by the Foundation will be pooled by the Regional Chapter and not provided directly to the Branches.
+Regional Chapter will pool OWASP Foundation shared services for their branches. Shared services are not provided directly to the Branches.
 
 ## Defining and Naming Chapters
 
-Chapter names should always aim to reduce confusion between the various chapter types to discover search engine. To that end, OWASP defines the following types of chapters and how they should be named:
+Chapter names should always reduce confusion between the various chapter types to discover in search engines. To that end, OWASP defines the following types of chapters and how they should be named:
 
 ### Defining and Naming City chapters
 
 City chapters are the primary form of the OWASP chapter, with hundreds of chapters worldwide.
 
-- Approved City chapters are named "OWASP «city name»". City chapter names must not be a regional or country name unless the city name is the country name (e.g., Monaco).
-- City chapters are defined for a single city only; a new chapter may be denied approval if another chapter is within 80 km (50 miles).
+- City chapters should be named "OWASP «city name»". City chapter names must not be a regional or country name unless the city name is the country name (e.g., Monaco).
+- City chapters are defined for a single city only.
 - City chapter leaders must reside within 80 km (50 miles) of the chapter location.
+- OWASP may deny approval for a new chapter if another chapter is within 80 km (50 miles).
 
-Exceptions to distance rules may be approved on a case-by-case basis, for example, where travel times between two geographically close chapters are excessive (defined as more than one hour).
+The Chapter Committee or OWASP Foundation may approve exceptions to distance rules on a case-by-case basis. For example, travel times between two geographically close chapters are excessive, such as more than one hour.
 
 ### Defining and Naming Student chapters
 
 Students and faculty of institutions of higher education can create Student chapters. As Student chapters are associated with an educational institution, there can be many Student chapters within a city, even cities with a City chapter.
 
 - Student chapters are named "OWASP «institution name»" or where the institution has different campus locations, "OWASP «institution name» «campus»"
-- Student chapters are associated with one educational institution in a single geographic area. For example, each educational institution in a city is more than welcome to have its own Student chapter, which is not the case for regular City chapters.
+- Student chapters are associated with one educational institution in a single geographic area. For example, every educational institution in a city can have a Student chapter, which is not the case for regular City chapters.
 - Student chapters must have at least one student leader and at least one leader from the institution's staff or faculty.
 
 Student chapters in a city with an active OWASP City chapter should make meaningful efforts to collaborate with the local City chapter, and vice versa, as appropriate.
 
 ### Defining and Naming Regional chapters
 
-A Regional chapter represents a larger geographic area with a cohesive community that is not limited to a specific city. This might be a state/district/province, a whole country, or a commonly recognized geographic area.
+A Regional chapter represents a larger geographic area with a cohesive community not limited to a specific city. A region might be a state/district/province, a whole country, or a commonly recognized geographic area.
 
-Regional chapters will have higher requirements and will require common consensus from the wider community in the area. (See "Starting a Regional chapter" for more details).
+Regional chapters will have higher requirements and require common consensus from the broader community in the area. (See "Starting a Regional chapter" for more details).
 
-Regional chapter names must be recognized by residents living in the region as commonly associated with the region.
+Regional chapters are to be named "OWASP «region name»" Residents living in the region must recognize regional chapter names as commonly associated with the region. For example, a fictional leader from Sto Plains cannot create "OWASP Ramtops" when the regional Chapter aims to encompass Sto Plains, not the Ramtops.
 
-The existence of a Regional chapter does not conflict with the existence of a City chapter co-located in the same region. However, there are additional requirements.
-
-There is no requirement to become a Regional chapter, even if multiple cities wish to run a joint event, and it is completely optional.
+The existence of a regional chapter does not conflict with a City chapter co-located in the same region. However, there are additional requirements to forming a regional chapter. There is no requirement to become a regional chapter, even if multiple cities wish to run a joint event, and it is entirely optional.
 
 ### Defining and Naming Regional branches
 
-A Regional chapter may optionally have one or more Branches in more remote locations. A Branch is not a full-fledged Chapter and is considered a local representative of the Regional Chapter. Branches will be approved and managed by the leaders of the Regional Chapter, supported by OWASP Staff.
+A Regional chapter may optionally have one or more Branches in more remote locations. A Branch is not a full-fledged Chapter and is considered a local representative of the Regional Chapter. Branches will be approved and managed by the leaders of the Regional Chapter, supported by the OWASP Foundation.
 
 Branches should follow the naming rules of City chapters.
 
 ## Chapter Leadership
 
-Chapter leaders serve as the main point of contact for their chapters and are responsible for ensuring the Chapter complies with all OWASP policies while fulfilling its mission and obligations.
+Chapter leaders serve as the main point of contact for their chapters and ensure they comply with all OWASP policies while fulfilling its mission and obligations.
 
-- Chapter leaders are not required to be members, but it is recommended to become one to promote membership.
+- Chapter leaders are not required to be members. The OWASP Foundation recommends membership to all leaders and participants to support our mission.
 - Chapter leadership is open to all participants. Leadership is personal and not associated with any organization, company, or employer.
-- Each Chapter must have a minimum of 2 and a maximum of 5 Foundation-recognized, official leaders. In the event of a resignation, leadership transition, or new leadership being appointed, a chapter is allowed a grace period of up to 3 months from the event to comply.
+- Each Chapter must have a minimum of two (2) and a maximum of five (5) OWASP Foundation-recognized, official leaders. Chapters have three months to have sufficient leaders after a leader's resignation, or if leadership is vacated, such as through inactivity.
 - A chapter leader can be a leader of only one Chapter.
 - Leaders will sign and return a leader's agreement within 30 days of receipt.
 - Each leader will annually confirm upon request within 30 days that they intend to continue volunteering as chapter leader.
 - Leaders are encouraged to transition or rotate every 2-3 years (minimum two years, maximum three years) to allow fresh leaders to step up and participate in the chapter operations. Leader selection is at the Chapter's discretion, provided all policies are followed.
-- If a chapter's leadership does not have consensus, fair and open elections should be administered with the support of OWASP staff and the [Chapter Committee](https://owasp.org/www-committee-chapter/).
-- Any changes in chapter leadership should be done by submitting a ticket with all information to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105) by one of the existing leaders. If the local chapter leadership is inactive, this request can be made by local chapter OWASP members.
+- If a chapter's leadership does not have consensus, Chapter leaders should log a ticket to run a free and fair election.
+- Any changes in chapter leadership should be done by submitting a ticket with all information to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105) by one of the existing leaders. If the local chapter leadership is inactive, local chapter members can request new leadership using this form.
 - If a leader needs to step down, they should submit a ticket to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105).
-- If a leader is no longer reasonably responsive and contributing to the Chapter, the remaining chapter leaders may petition the leader's removal in accordance with the dispute resolution process.
+- If a leader is no longer reasonably responsive and contributing to the Chapter, the remaining chapter leaders may petition the leader's removal following the dispute resolution process.
 
 ### Student chapter Leadership
 
@@ -174,50 +177,46 @@ Student chapters must adhere to City leadership as above, but in addition:
 - Student chapters must have at least one student leader and at least one leader from the institution's staff or faculty;
 - If a student graduates from the institution or a faculty member no longer works at the institution, they can no longer be a Student chapter leader.
 
-Student chapters do not need to meet minimum student leadership requirements during a semester or year breaks but must come back into compliance within 30 days of a new semester or year starting.
+Student chapters do not need to meet minimum student leadership requirements during semester or year breaks. Still, they must come back into compliance within 30 days of starting a new semester or year.
 
 ### Regional chapter Leadership
 
 Regional chapter leaders have more requirements than City or Student chapters:
 
 - Regional Leadership management is the same as per City chapters;
-- Regional chapters must have at least three and usually a maximum of five Foundation-recognized leaders. If the region has more than five participating locations, it can have up to seven (7) leaders.
+- Regional chapters must have at least three and usually a maximum of five OWASP Foundation-recognized leaders. If the region has more than five participating locations, it can have up to seven (7) leaders.
 
 ### Regional branch Leadership
 
-A Branch must have at least one active Organizer and up to 3 official Organizers. Branch Organizers do not have to be Leaders but can additionally support the Regional Chapter as Leaders.
+A Branch must have at least one active Organizer and up to three official Organizers. Branch Organizers do not have to be Leaders but can additionally support the Regional Chapter as Leaders.
 
 Branch Organizers do not automatically become Leaders or Members but may also be Leaders of the Regional Chapter. Branch Organizers do not receive any benefits.
 
-Regional Chapter Leaders should attempt to find cost-effective ways to show appreciation for persistent Organizers. In addition, Regional Chapter Leaders are expected to mentor Branch Organizers in community management and organizing meetups.
+Regional Chapter Leaders should attempt to find cost-effective ways to show appreciation for persistent Organizers. Regional Chapter Leaders should mentor Branch Organizers in community management and organizing meetups.
 
 ## Starting a new chapter
 
-Prospective chapter leaders should familiarize themselves with this policy and the draft [Chapter Handbook](https://owasp.org/www-committee-chapter/#div-resources_for_chapters) prior to submitting the form.
+Prospective chapter leaders should familiarize themselves with this policy and the draft [Chapter Handbook](https://owasp.org/www-committee-chapter/#div-resources_for_chapters) before submitting an application to start a new chapter.
 
-- New chapters must be approved by the Foundation by submitting a request through [Contact Us](https://contact.owasp.org/).
-- After the new Chapter is approved, the chapter leader must:
-  - Provide GitHub usernames in order to get admin access to your chapter repository.
-  - Create new chapter pages within 30 days of GitHub access on the owasp.org website (see [Website Migration Information and Tutorial](https://owasp.org/migration/) for assistance).
-  - Log into their owasp.org email account within Google's defined time period, or they will need to log a support ticket via [Contact Us](https://contact.owasp.org/) to have a password recovery email sent to their registered email address.
+Prospective Chapter leaders must submit a request through [Contact Us](https://contact.owasp.org/). If all policy requirements are met, the OWASP Foundation will create the new chapter.
 
-### Starting a City or Student chapter
+After the new Chapter is created by the OWASP Foundation, chapter leaders must:
 
-All the above requirements for starting a chapter must be met.
+- Provide GitHub usernames to get admin access to your chapter repository.
+- Create new chapter pages within 30 days of GitHub access on the owasp.org website (see [Website Migration Information and Tutorial](https://owasp.org/migration/) for assistance).
+- Log into their owasp.org email account before the Google invite expires. If the invite expires, leaders will need to log a support ticket via [Contact Us](https://contact.owasp.org/) to send a password recovery email to their registered email address.
 
 ### Starting a Regional chapter
 
-Regional Chapters will only be created with the approval of the Chapter Committee after confirming the below requirements (in particular the first three bullet points below).
-
-All of the following requirements must be met to start a new regional chapter.
+Regional leaders must meet all the following requirements to start a new regional chapter.
 
 - All "Starting a New City chapter" requirements must be met;
-- Consensus on the creation of a new Regional chapter is required by at least three different City chapter leaders from within the region, each at least 80 km (50 miles) apart;
-- All City chapter leaders within the defined region must agree to the creation of the new Regional Chapter, and there must be no *dissenting* City chapter leaders within the region;
+- At least three different City chapter leaders, each at least 80 km (50 miles) apart, from within the region must have consensus on the creation of a new regional chapter. Regional chapter leadership must include at least three of these chapter leaders.
+- All City chapter leaders within the defined region must agree to the creation of the new Regional Chapter, and there must be no *dissenting* City chapter leaders within the region.
 - The new region chapter name must be recognized by residents living in the region as commonly associated with the region; and
 - If there are overlapping regions, the new Regional Chapter will be the smallest of the overlapping regions that incorporate all participating locations.
 
-Initial leadership must include the leaders from the initial consensus and from at least three different locations.
+The OWASP Foundation will only create regional Chapters with the approval of the Chapter Committee after confirming regional policy requirements are met.
 
 Regional Chapters must perform a "health check" of the "Starting a Regional Chapter" requirements with the Chapters Committee at least once a year.
 
@@ -229,15 +228,15 @@ A Branch cannot exist independently without a managing Regional chapter. A Regio
 
 - Branches will not have their own page on the OWASP website but should be listed on the Regional Chapter's webpage.
 
-If the Regional Conference (as per B.3.b.(i) above) results in a net profit, the Regional Chapter may elect to provide a Meetup.com group or other shared service (under the regular OWASP account) for an active Branch at the Regional Chapter's own expense, if approved by the leaders of the Regional Chapter. This will be provided by OWASP Staff, on condition that the profits from the Regional Conference can cover the costs of the service. The costs of these Branch groups shall not be borne by the OWASP Foundation.
+If an AppSec Day event results in a net profit, the Regional Chapter may elect to provide a Meetup.com group or other shared service (under the regular OWASP account) for an active Branch at the Regional Chapter's own expense, if approved by the leaders of the Regional Chapter. Shared services will be provided by the OWASP Foundation, on condition that the profits from the Regional Conference can cover the costs of the service. The OWASP Foundation shall not bear the costs of Branches.
 
-Branches are managed solely by the Regional Chapter and do not directly require Staff involvement. Regional chapter Leaders are responsible for their Branch's meeting requirements, for their continued activities, and for mentoring their Branch Organizers as needed. This will be additionally monitored by the Chapter Committee on a yearly basis.
+Branches are managed solely by the Regional Chapter and do not directly require OWASP Foundation involvement. Regional chapter Leaders are responsible for their Branch's meeting requirements, continued activities, and mentoring their Branch Organizers as needed. The Chapter Committee will additionally monitor this yearly.
 
-If a Branch meets the standard requirements for a City chapter, they can opt to "graduate" to a full Chapter, as long as they continue to meet the requirements. However, while this should be encouraged, it is not mandatory, and they may continue as a Branch. If the Branch does become a Chapter, the Regional Chapter must continue to meet its requirements as well.
+If a Branch meets the standard requirements for a City chapter, they can opt to "graduate" to a full Chapter, as long as they continue to meet the requirements. However, while this should be encouraged, it is not mandatory, and they may continue as a Branch. If the Branch does become a Chapter, the Regional Chapter must continue to meet its requirements.
 
 ### Renaming a Chapter
 
-- Any chapter name changes must be approved by the Foundation. A request for approval must be submitted through [Contact Us](https://contact.owasp.org/).
+- The OWASP Foundation must approve any chapter name changes. Chapter leaders must submit a request for approval through [Contact Us](https://contact.owasp.org/).
 
 ## Inactive Chapters
 
@@ -246,21 +245,23 @@ The OWASP Foundation aims to provide continuity for OWASP chapter members. The f
 - An inactive OWASP chapter is a chapter that has not met [minimum activity requirements](#meetings-and-activity-requirements) defined in this policy.
 - An inactive chapter must either be reactivated or dissolved.
 - The OWASP Foundation will revoke the inactive chapter leadership and refer the inactive Chapter to the [Chapter Committee](https://owasp.org/www-committee-chapter/) to help find fresh leadership or to run elections to elect new leadership.
-- Use this form to [reactivate a chapter](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105). Where an inactive chapter does not hold a meeting within 90 days of being reactivated, or new leadership could not be appointed within 90 days of failing to meet activity targets, the [Chapter Committee](https://owasp.org/www-committee-chapter/) will discuss the inactive Chapter and vote on it. If agreed, the Chapter will be dissolved by the OWASP Foundation.
+- Use this form to [reactivate an inactive chapter](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105).
+
+Where an inactive chapter does not hold a meeting within 90 days of being reactivated, or new leadership could not be appointed within 90 days of failing to meet activity targets, the [Chapter Committee](https://owasp.org/www-committee-chapter/) will discuss the inactive Chapter and vote on it. If agreed, the Chapter will be dissolved by the OWASP Foundation.
 
 ## Regional chapter conflict resolution
 
-A Regional Chapter can exist with additional City Chapters that overlap in the same region, in the following circumstances only. In the case of overlapping Regional Chapter and City Chapter, these will be independent of each other and will not have control or influence over the other. In any unresolved event, the Chapters Committee will be the arbiters and provide a final decision.
+A Regional Chapter can exist with additional City Chapters that overlap in the same region only in the following circumstances. In the case of overlapping Regional Chapter and City Chapter, these will be independent of each other and will not have control or influence over any other chapter. The Chapters Committee will be the arbiters and provide a final decision in any unresolved event.
 
-### Creating a new Regional Chapter where City Chapters exist
+### Creating a new Regional Chapter where City Chapters already exist
 
-New Regional Chapters may only be created upon the approval of the Chapters Committee. If the proposed Regional Chapter meets the requirements set out in "Starting a new Regional chapter," the staff will refer the Regional Chapter leaders to the Chapters Committee.
+The Chapters Committee must approve all new Regional Chapters. If the proposed Regional Chapter meets the requirements set out in "Starting a new Regional chapter," the OWASP Foundation will refer the Regional Chapter leaders to the Chapters Committee.
 
-The Chapters Committee will review the Regional Chapter's proposal and discuss with relevant City Chapters as needed. The Chapters Committee will vote on the proposed Regional Chapter at the next Committee meeting after the review is completed.
+The Chapters Committee will review the Regional Chapter's proposal and discuss with relevant City Chapters as needed. The Chapters Committee will vote on the proposed Regional Chapter at the next Committee meeting after completing the review.
 
-In order to create a new Regional Chapter, there must be no existing chapters or active community leaders in the same region that object to the creation of this Regional Chapter, e.g., leaders of a City Chapter in the region claims that there is no regional community, or that the region does not include those cities.
+There must be no existing chapters or active community leaders in the same region that object to creating this Regional Chapter, e.g., leaders of a City Chapter in the region claim that there is no regional community or that the region does not include those cities.
 
-If there are existing City Chapters in the same region, and the leaders of said chapters concur with the Regional Chapter's claims AND agree that the Regional Chapter can coexist, then the overlapping Regional Chapter can be created.
+If there are existing City Chapters in the same region, and the leaders of said chapters concur with the Regional Chapter's claims AND agree that the Regional Chapter can coexist, then the OWASP Foundation can create the overlapping Regional Chapter.
 
 The City Chapter may opt to join the Regional Chapter as a Participating Chapter, downgrade to a Branch, or remain an independent overlapping City Chapter (with no connection to the Regional Chapter).
 
@@ -268,29 +269,29 @@ The City Chapter may opt to join the Regional Chapter as a Participating Chapter
 
 Where all requirements are met for starting a new City chapter, and the proposed City chapter lies within the defined region of an existing Regional chapter that meets all regional chapter requirements (including consensus), the requesting City Chapter leaders will first be referred to the leaders of the overlapping Regional Chapter to discuss mutually beneficial solutions, such as organizing an additional Branch of the Regional Chapter. The Chapters Committee will mediate as necessary.
 
-However, if such a solution cannot be mutually agreed upon, the Regional Chapter will not have the power to block the City Chapter from being created. The new City Chapter will be created and exist independently of the Regional Chapter, with no effect on the Regional Chapter and no influence between the two.
+However, if Chapter leaders cannot mutually agree upon a solution, the existing Regional Chapter will not have the power to block the new City Chapter from being created by the OWASP Foundation. The new chapter will exist independently of the Regional Chapter, with no effect on the Regional Chapter and no influence between the two.
 
 The above will only apply if none of the Regional Chapter Leaders are from the same city as the proposed City Chapter. If leaders of the Regional Chapter reside/work in the same city in which the City Chapter is wanted to be created, and there are multiple activities held in the city, they will be considered the leaders of the City Chapter and will independently reach a decision regarding the creation of this City Chapter. The Chapter Committee will interpret this as a situation wherein someone wants to create a new City Chapter in the same city where an active City Chapter exists.
 
-Note that both the City Chapter and the Regional Chapter must continue to meet their respective requirements. In particular, the Regional Chapter must still retain consensus from other community members, excluding the city wherein the City chapter exists. The Regional Chapter must have consensus from leaders in at least three cities, not including the one where the City Chapter is created.
+Note that both the City Chapter and the Regional Chapter must continue to meet their individual requirements. In particular, the Regional Chapter must still retain consensus from other community members, excluding the city wherein the City chapter exists. The Regional Chapter must have consensus from leaders in at least three cities, not including the one where the City Chapter is created.
 
 ## Finances, Oversight, and Transparency
 
-Chapters are overseen on an operational basis by the [Chapter Committee](https://owasp.org/www-committee-chapter/), the OWASP Foundation staff, and, ultimately, the OWASP Board of Directors. Leaders who have not complied with this policy, leadership privileges may be revoked, suspended, or another action taken. The OWASP Foundation may revoke the leader's access to all OWASP accounts, shared services, including the leader's email, and any privileged functionality upon notification by the Chapter Committee, the OWASP Foundation, or Board of Directors of a breach of this policy.
+Chapters are overseen on an operational basis by the [Chapter Committee](https://owasp.org/www-committee-chapter/), the OWASP Foundation, and, ultimately, the OWASP Board of Directors. Leaders who have not complied with this policy, leadership privileges may be revoked, suspended, or another action taken. The OWASP Foundation may revoke the leader's access to all OWASP accounts, shared services, including the leader's email, and any privileged functionality upon notification by the Chapter Committee, the OWASP Foundation, or Board of Directors of a breach of this policy.
 
 ### Code of Conduct and Other Relevant Policies
 
 All leaders must follow and adhere to the latest published OWASP Foundation [policies and procedures](https://owasp.org/www-policy/). As a US-based 501 (c)(3) non-profit organization, OWASP must follow specific financial and legal guidelines that can change from time to time.
 
-Chapters operate with a great deal of freedom; however, chapters must abide by the latest approved [Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct), [Foundation Bylaws](https://owasp.org/www-policy/legal/bylaws), and these [policies and procedures](https://owasp.org/www-policy/). Copies of older versions are not relevant.
+Chapters operate with a great deal of freedom; however, chapters must abide by the latest approved [Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct), [OWASP Foundation Bylaws](https://owasp.org/www-policy/legal/bylaws), and these [policies and procedures](https://owasp.org/www-policy/). Copies of older versions are not relevant.
 
 ### Privacy
 
-OWASP membership and participation in chapter meetings are subject to locally applicable data protection regulations (for instance, see [GDPR](https://gdpr.eu)). Where conflicting local regulations exist, Chapter leaders should observe the most restrictive. All chapter meetings must comply with [OECD principles](https://www.oecd.org/sti/ieconomy/oecd_privacy_framework.pdf); the Collection Limitation Principle applies to all activities where personal information of participants is needed. Chapter leaders are not permitted to share member lists, event attendees, or private information with third parties except where operationally necessary and only after informing relevant parties with opt-in acceptance. Chapters should, where possible and not otherwise required by local legislation or compliance requirements, adopt a data minimization approach and delete data that is no longer necessary.
+OWASP membership and participation in chapter meetings are subject to locally applicable data protection regulations (for instance, see [GDPR](https://gdpr.eu)). Where conflicting local regulations exist, Chapter leaders should observe the most restrictive. All chapter meetings must comply with [OECD principles](https://www.oecd.org/sti/ieconomy/oecd_privacy_framework.pdf); the Collection Limitation Principle applies to all activities where personal information of participants is needed. Chapter leaders are not permitted to share member lists, event attendees, or confidential information with third parties except where operationally necessary and only after informing relevant parties with opt-in acceptance. Chapters should, where possible and not otherwise required by local legislation or compliance requirements, adopt a data minimization approach, and delete data that is no longer necessary.
 
 ### Submitting Expenses
 
-Chapter-related expenses incurred while holding a chapter meeting within the Chapter's geographic area must comply with the [expense policy](https://owasp.org/www-policy/operational/expense-reimbursement) and must be submitted within 60 days. The OWASP Foundation cannot reimburse chapter expenses for events or activities outside the Chapter's geographic area without prior approval.
+Chapter-related expenses incurred while holding a chapter meeting within the Chapter's geographic area must comply with the [expense policy](https://owasp.org/www-policy/operational/expense-reimbursement) and must be submitted within 60 days. The OWASP Foundation cannot reimburse chapter expenses for events or activities outside the Chapter's geographic area without expense pre-approval.
 
 The OWASP Foundation will manage regional chapter expenses the same way as City chapter expenses.
 
@@ -310,7 +311,7 @@ Donations will be processed per the [donation policy](https://owasp.org/www-poli
 
 The OWASP Foundation will process free chapter training events, activities, workshops, and other local events not covered by the Events policy per the [expense policy](https://owasp.org/www-policy/operational/expense-reimbursement). Expense pre-approval limits and leader co-approvals apply.
 
-The OWASP Foundation will process paid local or AppSec Days (formerly regional) events. These events are pre-approved in OCMS per the [Events policy](https://owasp.org/www-policy/operational/events), only if the Event policy applies. The Events policy does not apply to most free chapter meetings, local activities, or minor events. If in doubt, please [raise a ticket](https://contact.owasp.org).
+The OWASP Foundation will process paid local or AppSec Days (formerly regional) events. According to the [Events policy], these events are pre-approved in OCMS per the [Events policy](https://owasp.org/www-policy/operational/events), but only if the Event policy applies. The Events policy does not apply to most free chapter meetings, local activities, or minor events. If in doubt, please [raise a ticket](https://contact.owasp.org).
 
 For more information, leaders should review and follow the following policies:
 
@@ -323,15 +324,15 @@ The OWASP Foundation has authority over all OWASP chapters, projects, committees
 
 ### Finances are via OWASP Foundation Only
 
-Chapters are not legal entities. The OWASP Foundation will process all membership dues and funds for transparency, US not-for-profit laws, regulations, and tax compliance. Chapters are not permitted to hold or use independent bank accounts, insurance, donation mechanisms. Chapters cannot ex[ense or use funds transfer mechanisms to store financial value such as gift cards, PayPal or Venmo, or other banking or financial instruments.
+Chapters are not legal entities. The OWASP Foundation will process all membership dues and funds for transparency, US not-for-profit laws, regulations, and tax compliance. Chapters are not permitted to hold or use independent bank accounts, insurance, donation mechanisms. Chapters cannot expense or use funds transfer mechanisms to store financial value such as gift cards, PayPal or Venmo, or other banking or financial instruments.
 
 ### Signing Authority
 
-Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory2). As for non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. Chapter leaders should refer all such agreements to the OWASP Foundation for pre-approval and possible signing.
+Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory2). As for non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. Chapter leaders should refer all such contracts to the OWASP Foundation for pre-approval and subsequent signing.
 
 ### Supporters and Bartering Arrangements
 
-Chapters are encouraged to obtain local chapter supporters via bartering arrangements (i.e., services, event spaces, or food and beverages are paid for by a chapter supporter) and donations via the OWASP website. Chapters can define the levels and benefits of local Chapter Supporters, including logos on the introduction slides and the Chapter home page. Any contractual agreement, bartering arrangement, or financial transaction must be registered and processed by the Foundation through our [service desk](https://contact.owasp.org/)
+Chapter leaders are encouraged to obtain local chapter supporters via bartering arrangements (i.e., services, event spaces, or food and beverages are paid for by a chapter supporter) and donations via the OWASP website. Chapters can define the levels and benefits of local Chapter Supporters, including logos on the introduction slides and the Chapter home page. Any contractual agreement, bartering arrangement, or financial transaction must be registered and processed by the OWASP Foundation through our [service desk](https://contact.owasp.org/)
 
 ### Disputes
 
@@ -341,25 +342,25 @@ Chapter members and leaders can use the following policies and reporting mechani
 
 - [Conflict resolution policy](https://owasp.org/www-policy/operational/conflict-resolution) for most disputes between participants.
 - [Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct) policy for ethical or conduct breaches.
-- The [OWASP Chapter Committee](https://owasp.org/www-committee-chapter/) is the first escalation point.
-  - The [Executive Director](https://owasp.org/corporate/) as the second point of escalation, and finally.
+- The first escalation point is the [OWASP Chapter Committee](https://owasp.org/www-committee-chapter/).
+  - The [OWASP Foundation Executive Director](https://owasp.org/corporate/) as the second point of escalation, and finally.
   - the [Global Board](https://owasp.org/www-board/).
 
-To report severe policy, financial, or fiduciary misconduct violations, please refer to the [whistleblower and anti-retaliation policy](https://owasp.org/www-policy/operational/whistleblower).
+Please refer to the [whistleblower and anti-retaliation policy] to report severe policy, financial, or fiduciary misconduct violations. Please refer to the [whistleblower and anti-retaliation policy](https://owasp.org/www-policy/operational/whistleblower).
 
 ### Sanctioned Countries and Leaders
 
-OWASP must comply with international laws and regulations, including international sanctions. Sanctions take many forms and are often limited in scope to access specific intellectual property, organizations, governments, or individuals.
+OWASP must comply with international laws and regulations, including international sanctions. Sanctions take many different forms. Sanctions are often limited in scope to specific intellectual property, organizations, governments, or individuals.
 
-From time to time, the Executive Director and Community Manager will review sanctions from the EU, USA, and anywhere else the Foundation has an operating entity and apply the following policies.
+From time to time, the OWASP Foundation will review sanctions from the EU, USA, and anywhere else the OWASP Foundation has an operating entity and apply the following policies.
 
 The OWASP Foundation must comply with US Government or EU sanctions. Breaching sanctions may cause the OWASP Foundation to be subject to fines, civil or criminal liability. The following policies apply against sanctioned individuals, entities, or countries to manage this risk:
 
-a) New chapters cannot be formed.
-b) Existing chapters may be disbanded or made independent of the Foundation depending on the nature of the sanctions.
-c) For sanctioned leaders and members, the OWASP Foundation will remove individuals from any leadership positions and any membership fees refunded, including Lifetime membership.
-d) Access to OWASP materials is free and open-source, and can be obtained through any means, including OWASP shared cloud platforms. OWASP relies solely upon the technical controls in place by our shared cloud platforms to prevent access or prohibit the "export" of such freely available information. The OWASP Foundation has no control over these technical controls. The OWASP Foundation will not subvert these technical controls to allow access in sanctioned countries.
+- New chapters cannot be formed.
+- Existing chapters may be dissolved or made independent of the OWASP Foundation, depending on the nature of the sanctions.
+- For sanctioned leaders and members, the OWASP Foundation will remove individuals from any leadership positions and any membership fees refunded, including Lifetime membership.
+- Access to OWASP materials is free and open-source, and can be obtained through any means, including OWASP shared cloud platforms. OWASP relies solely upon the technical controls in place by our shared cloud platforms to prevent access or prohibit the "export" of such freely available information. The OWASP Foundation has no control over these technical controls. The OWASP Foundation will not subvert these technical controls to allow access from sanctioned countries.
 
 The OWASP Foundation will inform the OWASP Global Board and Chapter Committee of any sanctioned chapters, leadership, or access changes.
 
-The OWASP Foundation will periodically review the list of sanctioned chapters and leaders to determine if the Foundation can restore the Chapter, leadership, and membership.
+The OWASP Foundation will periodically review the list of sanctioned chapters and leaders to determine if the OWASP Foundation can restore the Chapter, leadership, and membership.

--- a/operational/chapters.md
+++ b/operational/chapters.md
@@ -8,11 +8,13 @@ notice: 2021-02-23
 
 ---
 
-DRAFT Regional chapter PROPOSAL. This document is not policy.
+{% include draft-notice.html %}
+
+This is a DRAFT Chapter policy incorporating improvements to the existing policy as well as incorporating a standardized regional model created by the Chapter Committee after more than a year of consultations with all OWASP regional chapters. Please provide comments on this policy via the [Community Review Process](https://owasp.org/www-policy/operational/community-review-process).
 
 ## Overview
 
-Chapters are central to OWASP's mission of building a community of appsec professionals and developers around the world. This policy defines various chapter types, starting, running, maintaining, and dissolving OWASP chapters.
+Chapters are central to OWASP's mission of building a community of appsec professionals and developers around the world. This policy defines various chapter types, starting, running, maintaining, and dissolving OWASP chapters. Prospective chapter leaders should familiarize themselves with this policy and the [Chapter Committee leader resources](https://owasp.org/www-committee-chapter/#div-resources_for_chapters) prior to submitting the form.
 
 ## Running a Chapter
 
@@ -23,32 +25,31 @@ Chapters must be discoverable by new and existing members and participants.
 - Chapter activities must appear on the owasp.org website.
 - Chapter leaders should use OWASP's official chapter and event scheduling platform. The OWASP Foundation pays event platform fees for active chapters.
 - If you use the OWASP Foundation's scheduling service, your Chapter's group account must be defined under the OWASP Foundation account. Using the OWASP Foundation's scheduling service provides continuity for chapter members if chapter leadership becomes inactive.
-- If you do not use OWASP's official event platform, you must mirror your events (whether automatically or manually) to your chapter page on the owasp.org website. The OWASP Foundation is not obliged to reimburse alternate meeting scheduling services expenses.
-- Each chapter is responsible for creating and maintaining their owasp.org chapter home page (see also [Starting a New Chapter](#starting-a-new-chapter) and [Meetings and Activity Requirements](#meetings-and-activity-requirements)).
-- A list of the current leaders and email addresses must be listed on the Chapter's web page on owasp.org. Leaders are strongly encouraged to use their @owasp.org email address on their chapter pages.
+- If you do not use OWASP's official event platform, you must mirror your events (whether automatically or manually) to your chapter page on the owasp.org website. The OWASP Foundation is not obligated to reimburse for the use of alternative platform service expenses.
+- Each chapter is responsible for creating and maintaining their owasp.org chapter home page (see also [Starting a New Chapter](#div-starting-a-new-chapter) and [Meetings and Activity Requirements](#div-meetings-and-activity-requirements)).
 
 ### Meetings and Activity Requirements
 
 - Attendees do not need to be members. All members of the public are allowed to attend OWASP meetings. However, chapter leaders may organize restricted chapter events and activities in addition to regular meetings.
 - Chapter meetings must be free to attend, both in monetary and access terms
-- Chapters should host a minimum of 3 chapter activities a year to maintain an active OWASP chapter. The activity can be in person, virtual, or an [approved OWASP event](https://owasp.org/www-policy/operational/events) run by the OWASP chapter (or in collaboration with another chapter or external organization with the approval of the OWASP Foundation).
+- Chapters must host a minimum of 3 chapter activities a year to maintain an active OWASP chapter. The activity can be in person, virtual, or an [approved OWASP event](https://owasp.org/www-policy/operational/events) run by the OWASP chapter (or in collaboration with another chapter or external organization with the approval of the OWASP Foundation).
 
 Chapter activities are for the benefit of the community and could include, but are not limited to:
 
-- Chapter meetings (traditional meetups)
+- Chapter meetings - virtual, hybrid, or in-person gatherings or meeting
 - Training days
 - Capture the Flag/Hack-a-Thon events
 - Local/Regional AppSec Days events
 - Student-focused activities, at secondary or college level
-- Chapter leaders must post chapter activity information (date, time, and location) on the owasp.org chapter page before the event start date.
+- Chapter leaders must post to their chapter home page on owasp.org before the meeting or activity starts with sufficient notice for people to attend. All event announcements need to include the date and time, location if in person, and/or the URL to a virtual meeting if hybrid or virtual.
 
-For chapters using OWASP Meetup Pro, mirroring meetings automatically is simple and easy. Chapter leaders should add the following code to minimize the amount of manual work required. In the header, please make sure the `meetup-group` parameter exists and is accurate:
+For chapters using the standard OWASP meeting platform, mirroring meetings automatically is simple and easy. Chapter leaders should add the following code to minimize the amount of manual work required. In the header, please make sure the `meetup-group` parameter exists and is accurate:
 
 ```javascript
 meetup-group: your-meetup-group
 ```
 
-The above code will automatically mirror your upcoming meeting information if the meetup-group header is identical to your OWASP Meetup Pro Group name. e.g., `meetup-group: OWASP-Colorado-Springs-Meetup`
+The above code will automatically mirror your upcoming meeting information if the meetup-group header is identical to your OWASP meeting platform group name. e.g., `meetup-group: OWASP-Colorado-Springs-Meetup`
 
 Add this line to where you would like your upcoming meetings to appear in the body automatically:
 
@@ -64,18 +65,18 @@ NB: Per the policy above, if you misconfigure or do not use the above automation
 
 Student chapters must adhere to the City chapter activity requirements.
 
-As tertiary institutions often have significant vacations between academic years or semesters, student chapter leaders should plan to meet activity requirements within each semester.
+As tertiary institutions often have significant vacations between academic years or semesters, Student chapter leaders should plan to meet activity requirements within each semester.
 
 #### Regional chapter Activity Requirements
 
 Regional chapters must meet the following activity requirements:
 
-- EITHER a minimum of THREE (3) activities per year in addition to a significant event under the events policy, e.g., an AppSec Day jointly run by all participating branches or Chapters;
+- EITHER a minimum of THREE (3) activities per year in addition to a significant event under the events policy, e.g., an AppSec Day jointly run by all associated branches or Chapters;
 - OR a minimum of SIX (6) activities per year, including all branch activities.
 
-Regional branch activities count towards Regional chapter activity requirements. Activities organized by participating City chapters do not count towards Regional chapter activity requirements.
+Regional branch activities count towards Regional chapter activity requirements. Activities organized by associated City chapters do not count towards Regional chapter activity requirements.
 
-#### Branch Activity Requirements
+#### Regional Branch Activity Requirements
 
 A Branch must host a minimum of one activity per year but should strive for more.
 
@@ -85,11 +86,12 @@ A Branch that is not meeting its minimum requirements should be reactivated by t
 
 OWASP is a social community, and we need to communicate with our community regularly.
 
+- A list of the current leaders and email addresses must be listed on the Chapter's web page on owasp.org.
 - Chapter leaders should use their owasp.org email address for all OWASP related correspondence.
-- Chapter leaders should regularly monitor their owasp.org email address and respond within nine business days.
+- Chapter leaders should regularly monitor their owasp.org email address and respond within nine business days. Leaders can forward owasp.org email to another platform.
 - Requests from the OWASP Foundation, such as expense claims, should be responded to by one or more chapter leaders within nine business days.
-- Leaders are encouraged, but not required, to monitor and participate in the [OWASP Leaders List](https://groups.google.com/u/1/a/owasp.org/g/leaders), other Google groups, and the Slack platform.
-- OWASP chapters can create and manage their own social media presence and other reasonable communication channels. Chapter leaders must share access to these accounts with all Chapter leaders. When a Chapter Leader steps down, the Chapter Leader should hand over the account administration to a remaining chapter leader.
+- Leaders are should monitor and participate in the [OWASP Leaders List](https://groups.google.com/u/1/a/owasp.org/g/leaders), other Google groups, and the Slack platform.
+- OWASP chapters can create and manage their own social media presence and other reasonable communication channels. Chapter leaders must share access to these accounts with all of the Chapter's leaders. When a Chapter Leader steps down, the Chapter Leader should hand over the account administration to an active chapter leader.
 
 If Chapter Leaders plan to take leave, please set an [out of office notification](https://support.google.com/mail/answer/25922?co=GENIE.Platform%3DDesktop&hl=en) on your owasp.org email to inform chapter members, the Chapter Committee, and the OWASP Foundation of the potential for delays in responding.
 
@@ -103,11 +105,13 @@ OWASP Foundation will provide chapters with the following shared services at no 
 - Social messaging app to communicate in real-time with the OWASP community.
 - Leaders should join leaders@owasp.org using their owasp.org email address.
 - Assistance and resources are available through the [Chapter Committee](https://owasp.org/www-committee-chapter/) and other [OWASP Committees](https://owasp.org/committees/).
-- Event insurance covering chapter meetings.
+- Insurance coverage for standard chapter meetings and local activities.
+
+If you are planning to host a longer or larger meeting or activity, or sign a contract with an event space, or take sponsorships, or charge a registration fee, OWASP deems these as AppSec Days events and not local chapter meetings or activities, as they will need a separate event insurance policy and different expense handling. Please [create an AppSec Days regional event in OCMS](https://owasporg.atlassian.net/servicedesk/customer/portal/7/group/19/create/82) and [follow the event policy](https://owasp.org/www-policy/operational/events). Event expenses are managed per event via a budgeting process. The Event policy covers approved spending mechanisms, including the ability for an event to establish awards, scholarships, and grants for various purposes. For more details, please see the Event policy, and the associated [Awards and Scholarships Policy](https://owasp.org/www-policy/operational/awards-and-scholarships) and the [Grant Policy](https://owasp.org/www-policy/operational/grants).
 
 Chapter leaders cannot expense services identical or similar to those provided by the OWASP Foundation without [prior approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107). Where possible, all chapters are encouraged to use a service that respects user privacy.
 
-The Chapter may seek a reasonable alternative to OWASP Foundation shared services only if there is no response after nine business days. Chapter leaders can do this by filling out a [Chapter Funding Pre-Approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107) ticket.
+The Chapter may seek a reasonable alternative to OWASP Foundation shared services only if there is no response to a [Chapter Funding Pre-Approval ticket](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107) after nine business days outside of published office closures. For Chapter leaders to be reimbursed for alternative platforms after no response, the leader must provide details in the pre-approval ticket that they have selected an alternative platform and any likely costs.
 
 ### Shared Services for Regional Branches
 
@@ -123,20 +127,23 @@ City chapters are the primary form of the OWASP chapter, with hundreds of chapte
 
 - City chapters should be named "OWASP «city name»". City chapter names must not be a regional or country name unless the city name is the country name (e.g., Monaco).
 - City chapters are defined for a single city only.
-- City chapter leaders must reside within 80 km (50 miles) of the chapter location.
-- OWASP may deny approval for a new chapter if another chapter is within 80 km (50 miles).
+- City chapters should be more than 80 km (50 miles) apart or more than one hour travel distance of the next nearest chapter.
+- City chapter leaders should reside in the same country as their city chapter.
 
-The Chapter Committee or OWASP Foundation may approve exceptions to distance rules on a case-by-case basis. For example, travel times between two geographically close chapters are excessive, such as more than one hour.
+The Chapter Committee or the OWASP Foundation may deny approval of a new city chapter if another city chapter is within 80 km (50 miles) or within one hour travel distance of an existing chapter. The Chapter Committee or OWASP Foundation may approve exceptions to distance rules on a case-by-case basis. For example, if two chapters are located close together, but in two separate countries, or if travel times are excessive and would limit participation as a result.
 
 ### Defining and Naming Student chapters
 
-Students and faculty of institutions of higher education can create Student chapters. As Student chapters are associated with an educational institution, there can be many Student chapters within a city, even cities with a City chapter.
+Student chapters are encouraged at all educational institutions. Student chapter members, leaders, and faculty have access to discounted OWASP membership rates as a member benefit, as long as membership registration email comes from the institution's email address. Once the student, leader, or faculty is no longer present at the insitution, membership rates revert to the standard rate.
+
+Students and faculty of institutions of higher education can create OWASP Student chapters associated with their educational institution, and optionally campus location.
 
 - Student chapters are named "OWASP «institution name»" or where the institution has different campus locations, "OWASP «institution name» «campus»"
-- Student chapters are associated with one educational institution in a single geographic area. For example, every educational institution in a city can have a Student chapter, which is not the case for regular City chapters.
 - Student chapters must have at least one student leader and at least one leader from the institution's staff or faculty.
+- Every educational institution in a region or city can form a Student chapter at one or more campus locations. Each campus location is treated as a separate Student chapter requiring separate Student chapter leadership, requiring at least one student and one faculty member. There cannot be more than one Student Chapter per campus location.
+- Student chapters can be created even if there are nearby city or encompassing regional chapters. Nearby city chapters or encompassing regional chapters do not control the Student chapter. Student chapters should collaborate with nearby city or regional chapters.
 
-Student chapters in a city with an active OWASP City chapter should make meaningful efforts to collaborate with the local City chapter, and vice versa, as appropriate.
+Students or Faculty can also create city chapters, as long as all city chapter requirements are met, but they will be city chapters, and do not have access to Student chapter benefits.
 
 ### Defining and Naming Regional chapters
 
@@ -166,9 +173,11 @@ Chapter leaders serve as the main point of contact for their chapters and ensure
 - Each leader will annually confirm upon request within 30 days that they intend to continue volunteering as chapter leader.
 - Leaders are encouraged to transition or rotate every 2-3 years (minimum two years, maximum three years) to allow fresh leaders to step up and participate in the chapter operations. Leader selection is at the Chapter's discretion, provided all policies are followed.
 - If a chapter's leadership does not have consensus, Chapter leaders should log a ticket to run a free and fair election.
-- Any changes in chapter leadership should be done by submitting a ticket with all information to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105) by one of the existing leaders. If the local chapter leadership is inactive, local chapter members can request new leadership using this form.
+- Any changes in chapter leadership must be done by submitting a ticket with all information to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105) by one of the existing leaders. If the local chapter leadership is inactive, local chapter members can request new leadership using this form.
 - If a leader needs to step down, they should submit a ticket to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105).
 - If a leader is no longer reasonably responsive and contributing to the Chapter, the remaining chapter leaders may petition the leader's removal following the dispute resolution process.
+
+Leader benefits will only apply to the first five chapter leaders.
 
 ### Student chapter Leadership
 
@@ -179,12 +188,16 @@ Student chapters must adhere to City leadership as above, but in addition:
 
 Student chapters do not need to meet minimum student leadership requirements during semester or year breaks. Still, they must come back into compliance within 30 days of starting a new semester or year.
 
+Leader benefits will only apply to the first five Student chapter leaders.
+
 ### Regional chapter Leadership
 
 Regional chapter leaders have more requirements than City or Student chapters:
 
 - Regional Leadership management is the same as per City chapters;
-- Regional chapters must have at least three and usually a maximum of five OWASP Foundation-recognized leaders. If the region has more than five participating locations, it can have up to seven (7) leaders.
+- Regional chapters must have at least three and usually a maximum of five OWASP Foundation-recognized leaders. If the region has more than five associated locations, it can have up to seven (7) leaders.
+
+Leader benefits will only apply to the first five regional chapter leaders.
 
 ### Regional branch Leadership
 
@@ -192,33 +205,37 @@ A Branch must have at least one active Organizer and up to three official Organi
 
 Branch Organizers do not automatically become Leaders or Members but may also be Leaders of the Regional Chapter. Branch Organizers do not receive any benefits.
 
-Regional Chapter Leaders should attempt to find cost-effective ways to show appreciation for persistent Organizers. Regional Chapter Leaders should mentor Branch Organizers in community management and organizing meetups.
+Regional Chapter Leaders should attempt to find cost-effective ways to show appreciation for persistent Organizers. Regional Chapter Leaders should mentor Branch Organizers in community management and organizing meetings.
+
+Leader benefits will only apply to the first five branch leaders.
 
 ## Starting a new chapter
 
-Prospective chapter leaders should familiarize themselves with this policy and the draft [Chapter Handbook](https://owasp.org/www-committee-chapter/#div-resources_for_chapters) before submitting an application to start a new chapter.
+Prospective chapter leaders should familiarize themselves with this policy before submitting an application to start a new chapter. The Chapter Committee maintains [resources for leaders to assist running a chapter](https://owasp.org/www-committee-chapter/#div-resources_for_chapters).
 
-Prospective Chapter leaders must submit a request through [Contact Us](https://contact.owasp.org/). If all policy requirements are met, the OWASP Foundation will create the new chapter.
+Prospective Chapter leaders must submit a request through [Contact Us](https://contact.owasp.org/), including GitHub account IDs for each leader. If all policy requirements are met, the OWASP Foundation will create the new chapter.
 
 After the new Chapter is created by the OWASP Foundation, chapter leaders must:
 
-- Provide GitHub usernames to get admin access to your chapter repository.
-- Create new chapter pages within 30 days of GitHub access on the owasp.org website (see [Website Migration Information and Tutorial](https://owasp.org/migration/) for assistance).
+- At least one leader, but preferably all leaders, must accept the GitHub invite before it expires. A leader with chapter repository admin rights can grant other leaders admin access.
+- Leaders must create new chapter pages in GitHub within 30 days of chapter approval, to publish their chapter's home page automatically on the owasp.org website. See [Website Migration Information and Tutorial](https://owasp.org/migration/) for assistance.
 - Log into their owasp.org email account before the Google invite expires. If the invite expires, leaders will need to log a support ticket via [Contact Us](https://contact.owasp.org/) to send a password recovery email to their registered email address.
+
+Automation validation for leader and membership benefits are tied to the leaders.md file. Any changes to chapter leadership should be done via the process outlined in [Chapter Leadership](#div-chapter-leadership). Please do not add or remove leaders from the leaders.md file without first submitting a ticket.
 
 ### Starting a Regional chapter
 
-Regional leaders must meet all the following requirements to start a new regional chapter.
+Regional leaders should meet all the following requirements to start a new regional chapter.
 
 - All "Starting a New City chapter" requirements must be met;
-- At least three different City chapter leaders, each at least 80 km (50 miles) apart, from within the region must have consensus on the creation of a new regional chapter. Regional chapter leadership must include at least three of these chapter leaders.
+- At least three prospective regional chapter leaders, each at least 80 km (50 miles) apart or more than an hour apart for smaller regions, from within the region must have consensus on the creation of a new regional chapter.
 - All City chapter leaders within the defined region must agree to the creation of the new Regional Chapter, and there must be no *dissenting* City chapter leaders within the region.
 - The new region chapter name must be recognized by residents living in the region as commonly associated with the region; and
-- If there are overlapping regions, the new Regional Chapter will be the smallest of the overlapping regions that incorporate all participating locations.
+- If there are overlapping regions, the new Regional Chapter will be the smallest of the overlapping regions that incorporate all associated locations.
 
 The OWASP Foundation will only create regional Chapters with the approval of the Chapter Committee after confirming regional policy requirements are met.
 
-Regional Chapters must perform a "health check" of the "Starting a Regional Chapter" requirements with the Chapters Committee at least once a year.
+Regional Chapters must perform a "health check" of the "Starting a Regional Chapter" requirements with the Chapters Committee at least once a year. Failing to meet minimum requirements may be cause for the regional chapter to be asked to resolve the identified policy gaps, leadership added or replaced, or in severe cases, disbanded altogether.
 
 ### Starting a Regional branch
 
@@ -228,7 +245,7 @@ A Branch cannot exist independently without a managing Regional chapter. A Regio
 
 - Branches will not have their own page on the OWASP website but should be listed on the Regional Chapter's webpage.
 
-If an AppSec Day event results in a net profit, the Regional Chapter may elect to provide a Meetup.com group or other shared service (under the regular OWASP account) for an active Branch at the Regional Chapter's own expense, if approved by the leaders of the Regional Chapter. Shared services will be provided by the OWASP Foundation, on condition that the profits from the Regional Conference can cover the costs of the service. The OWASP Foundation shall not bear the costs of Branches.
+If an AppSec Day event results in a net profit, the Regional Chapter may elect to provide a OWASP meeting platform group or other shared service (under the regular OWASP account) for an active Branch at the Regional Chapter's own expense, if approved by the leaders of the Regional Chapter. Shared services will be provided by the OWASP Foundation, on condition that the profits from the Regional Conference can cover the costs of the service. The OWASP Foundation shall not bear the costs of Branches.
 
 Branches are managed solely by the Regional Chapter and do not directly require OWASP Foundation involvement. Regional chapter Leaders are responsible for their Branch's meeting requirements, continued activities, and mentoring their Branch Organizers as needed. The Chapter Committee will additionally monitor this yearly.
 
@@ -242,7 +259,7 @@ If a Branch meets the standard requirements for a City chapter, they can opt to 
 
 The OWASP Foundation aims to provide continuity for OWASP chapter members. The following process is to determine inactive chapters and try to install fresh leadership.
 
-- An inactive OWASP chapter is a chapter that has not met [minimum activity requirements](#meetings-and-activity-requirements) defined in this policy.
+- An inactive OWASP chapter is a chapter that has not met [minimum activity requirements](#div-meetings-and-activity-requirements) defined in this policy.
 - An inactive chapter must either be reactivated or dissolved.
 - The OWASP Foundation will revoke the inactive chapter leadership and refer the inactive Chapter to the [Chapter Committee](https://owasp.org/www-committee-chapter/) to help find fresh leadership or to run elections to elect new leadership.
 - Use this form to [reactivate an inactive chapter](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105).
@@ -263,7 +280,7 @@ There must be no existing chapters or active community leaders in the same regio
 
 If there are existing City Chapters in the same region, and the leaders of said chapters concur with the Regional Chapter's claims AND agree that the Regional Chapter can coexist, then the OWASP Foundation can create the overlapping Regional Chapter.
 
-The City Chapter may opt to join the Regional Chapter as a Participating Chapter, downgrade to a Branch, or remain an independent overlapping City Chapter (with no connection to the Regional Chapter).
+The City Chapter may opt to join the Regional Chapter as an associated Chapter, downgrade to a Branch, or remain an independent overlapping City Chapter (with no connection to the Regional Chapter).
 
 ### Creating a new City Chapter within the region of an overlapping Regional Chapter
 

--- a/operational/chapters.md
+++ b/operational/chapters.md
@@ -1,6 +1,6 @@
 ---
 
-title: Chapters Policy
+title: Chapters Policy - Draft Regional Proposal (WIP)
 layout: col-document
 document: Rules of Procedure
 tags: Rules of Procedure
@@ -8,27 +8,11 @@ notice: 2021-02-23
 
 ---
 
-Adopted by the Board on 23-Feb-2021
+DRAFT Regional chapter PROPOSAL. This document is not policy.
 
 ## Overview
 
-Chapters are central to OWASP’s mission of achieving community around the world. This policy defines the rules related to starting, running, maintaining, and dissolving OWASP chapters.
-
-## Chapter Leadership
-
-Chapter leaders serve as the main point of contact for their chapters and are responsible for ensuring the chapter complies with all OWASP policies while fulfilling its mission and obligations.
-
-- Chapter leaders are not required to be members, but it is recommended to become one to promote membership.
-- Chapter leadership is open to all participants. Leadership is personal, and not associated with any organization, company, or employer.
-- Each chapter must have a minimum of 2 and a maximum of 5 foundation-recognized, official leaders. In the event of a resignation, leadership transition, or new leadership being appointed, a chapter is allowed a grace period of up to 3 months from the event to comply.
-- A chapter leader can be a leader of only one chapter.
-- Leaders will sign and return a leader's agreement within 30 days of receipt.
-- Each leader will annually confirm upon request within 30 days that they intend to continue volunteering as chapter leader.
-- Leaders are encouraged to transition or rotate every 2-3 years (minimum 2 years, maximum 3 years) to allow fresh leaders to step up and participate in the chapter operations. Leader selection is at the chapter’s discretion, provided all policies are followed.
-- If a chapter’s leadership does not have consensus, fair and open elections should be administered with the support of OWASP staff and the [Chapter Committee](https://owasp.org/www-committee-chapter/).
-- Any changes in chapter leadership should be done by submitting a ticket with all information to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105) by one of the existing leaders. If the local chapter leadership is inactive, this request can be made by local chapter OWASP members.
-- If a leader needs to step down, they should submit a ticket to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105).
-- If a leader is no longer reasonably responsive and contributing to the chapter, the remaining chapter leaders may petition the leader's removal in accordance with the dispute resolution process.
+Chapters are central to OWASP's mission of achieving community around the world. This policy defines the rules related to starting, running, maintaining, and dissolving OWASP chapters.
 
 ## Running a Chapter
 
@@ -37,23 +21,24 @@ Chapter leaders serve as the main point of contact for their chapters and are re
 Chapters must be discoverable by new and existing members and participants.
 
 - Chapter activities must appear on the owasp.org website.
-- It is strongly recommended to use OWASP’s official chapter and event scheduling platform. The foundation pays event platform fees for active chapters. If you use another platform, [OWASP may not reimburse these expenses](https://owasp.org/www-policy/operational/expense-reimbursement). If you do use the foundation’s scheduling service, your chapter’s group account must be defined under the OWASP Foundation account to provide continuity for chapter members in case chapter leadership becomes inactive.
-- If you do not use OWASP’s official event platform, you must ensure your events are synchronized (whether automatically or manually) to your chapter page on the owasp.org website.
+- It is strongly recommended to use OWASP's official chapter and event scheduling platform. The Foundation pays event platform fees for active chapters.
+- If you use the Foundation's scheduling service, your Chapter's group account must be defined under the OWASP Foundation account. Using the OWASP Foundation's scheduling service provides continuity for chapter members if chapter leadership becomes inactive.
+- If you do not use OWASP's official event platform, you must mirror your events (whether automatically or manually) to your chapter page on the owasp.org website. The OWASP Foundation is not obliged to reimburse alternate meeting scheduling services expenses.
 - Each chapter is responsible for creating and maintaining their owasp.org chapter home page (see also [Starting a New Chapter](#starting-a-new-chapter) and [Meetings and Activity Requirements](#meetings-and-activity-requirements)).
-- A list of the current leaders and email addresses must be listed on the Chapter’s web page on owasp.org. It is highly encouraged that leaders use their @owasp.org email address on these pages.
+- A list of the current leaders and email addresses must be listed on the Chapter's web page on owasp.org. Leaders are strongly encouraged to use their @owasp.org email address on their chapter pages.
 
 ### Meetings and Activity Requirements
 
-- Attendees do not need to be members. All members of the public are allowed to attend OWASP meetings. However, reasonable restricted chapter events and activities may be organized in addition to regular meetings.
+- Attendees do not need to be members. All members of the public are allowed to attend OWASP meetings. However, chapter leaders may organize reasonably restricted chapter events and activities in addition to regular meetings.
 - Chapter meetings must be free.
-- Chapters should host a minimum of 3 chapter activities a year to maintain an active OWASP chapter. The activity can be in person, virtual, or an [approved OWASP event](https://owasp.org/www-policy/operational/events) run by the OWASP chapter (or in collaboration with another chapter or external organization with the approval of the foundation).
-- Chapter activities are for the benefit of the community, and could include, but are not limited to:
-  - Chapter meetings (traditional meetups)
-  - Training days
-  - Capture the Flag/Hack-a-Thon events
-  - Local/Regional AppSec Days events
-  - Student-focused activities, at secondary and/or college level
-- Chapter activity information (date, time, and location) must be posted on the owasp.org chapter page before the event start date.
+- Chapters should host a minimum of 3 chapter activities a year to maintain an active OWASP chapter. The activity can be in person, virtual, or an [approved OWASP event](https://owasp.org/www-policy/operational/events) run by the OWASP chapter (or in collaboration with another chapter or external organization with the approval of the Foundation).
+- Chapter activities are for the benefit of the community and could include, but are not limited to:
+- Chapter meetings (traditional meetups)
+- Training days
+- Capture the Flag/Hack-a-Thon events
+- Local/Regional AppSec Days events
+- Student-focused activities, at secondary or college level
+- Chapter leaders must post chapter activity information (date, time, and location) on the owasp.org chapter page before the event start date.
 
 For chapters using OWASP Meetup Pro, mirroring meetings automatically is simple and easy. Add the following code to make your life a lot easier. In the header, please make sure the `meetup-group` parameter exists and is accurate:
 
@@ -63,7 +48,7 @@ meetup-group: your-meetup-group
 
 If the meetup-group header is identical to your OWASP Meetup Pro Group name (e.g. `meetup-group: OWASP-Colorado-Springs-Meetup`), the code will automatically mirror your upcoming meeting information as mandated by the policy above.
 
-Add this line to where you would like your upcoming meetings to automatically appear in the body:
+Add this line to where you would like your upcoming meetings to appear in the body automatically:
 
 ```javascript
 . { % include chapter_events.html group=page.meetup-group %}
@@ -71,75 +56,188 @@ Add this line to where you would like your upcoming meetings to automatically ap
 
 (Remove the space between `{` and `%` to make this work on your page)
 
-NB: Per the policy above, if you don't use this, or it's set up incorrectly, you will need to do this step manually. Once your events are done, please add past events to a past events tab. For a more detailed example, see [https://owasp.org/www-projectchapter-example/]
+NB: Per the policy above, if you don't use this, or it's set up incorrectly, you will need to do this step manually. Once an event is complete, please add it to the past events tab. For a more detailed example, see [https://owasp.org/www-projectchapter-example/]
+
+#### Student chapter Activity Requirements
+
+Student chapters must adhere to the City chapter activity requirements.
+
+As many tertiary institutions have extensive time off between academic years or semesters, leaders should plan to meet activity requirements within each semester, as activity is measured over the previous 12 months.
+
+#### Regional chapter Activity Requirements
+
+Regional chapters must meet the following activity requirements:
+
+- EITHER a minimum of THREE (3) activities per year in addition to a larger event under the events policy, e.g., AppSec Day jointly run by all participating branches or Chapters;
+- OR a minimum of SIX (6) activities per year, including all branch activities.
+
+Regional branch activities count towards Regional chapter activity requirements. Activities organized by participating City chapters do not count towards Regional chapter activity requirements.
+
+#### Branch Activity Requirements
+
+A Branch must host a minimum of one activity per year but should strive for more.
+
+A Branch that is not meeting its minimum requirements should be reactivated by the Regional chapter Leaders if possible, including nominating a new Branch Organizer. If they are not successful in reactivating the Branch and the Branch continues to fail its requirements, the Regional chapter Leaders must deactivate and even remove the Branch as necessary. This will be monitored yearly by the Chapters Committee.
 
 ### Communication
 
 OWASP is a social community, and we need to communicate with our community regularly.
 
-- Chapter leaders should use owasp.org email address for all OWASP related correspondence.
-- Chapter leaders should monitor their owasp.org email address regularly and respond within 9 business days.
-- Requests from OWASP staff, such as expense claims, should be responded to by one or more of the chapter leaders within 9 business days.
+- Chapter leaders should use their owasp.org email address for all OWASP related correspondence.
+Chapter leaders should regularly monitor their owasp.org email address and respond within nine business days.
+- Requests from OWASP staff, such as expense claims, should be responded to by one or more chapter leaders within nine business days.
 - Leaders are encouraged, but not required, to monitor and participate in the [OWASP Leaders List](https://groups.google.com/u/1/a/owasp.org/g/leaders), other Google groups, and the Slack platform.
-- OWASP chapters can create and manage their own social media presence and other reasonable communication channels. Access to these accounts must be shared with all leaders of the chapter. Administration of the account should be handed over to a remaining chapter leader when stepping down.
+- OWASP chapters can create and manage their own social media presence and other reasonable communication channels. Chapter leaders must share access to these accounts with all Chapter leaders. The account administration should be handed over to a remaining chapter leader when stepping down.
 
-We recommend chapter leaders set an [out of office notification](https://support.google.com/mail/answer/25922?co=GENIE.Platform%3DDesktop&hl=en) within their @owasp.org email if they are planning to take leave, so that chapter members, the Chapter Committee, and foundation staff are aware of any absences or delays in responding to communications.
+We recommend that chapter leaders set an [out of office notification](https://support.google.com/mail/answer/25922?co=GENIE.Platform%3DDesktop&hl=en) within their @owasp.org email if they are planning to take leave, so that the chapter members, the Chapter Committee, and Foundation staff are aware of any absences or delays in responding to communications.
 
 ## Shared Services
 
-OWASP Foundation will provide chapters with the following shared services at no cost. Chapters are encouraged to make use of these. Access to these services can be obtained by submitting a ticket via [Contact Us](https://contact.owasp.org/). If, after 9 business days have passed, and reasonable efforts have been made to attempt to utilize shared services, no response is received, the chapter may, with due care, seek a reasonable alternative, filling out a [Chapter Funding Pre-Approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107) ticket.
+OWASP Foundation will provide chapters with the following shared services at no cost. Chapters are encouraged to use these. Chapter leaders can access these services by submitting a ticket via [Contact Us](https://contact.owasp.org/). If, after nine business days have passed, and reasonable efforts have been made to attempt to utilize shared services, no response is received, the Chapter may, with due care, seek a reasonable alternative, filling out a [Chapter Funding Pre-Approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107) ticket.
 
 - Chapter page on the owasp.org website.
 - A chapter scheduling service for meetings and local events with RSVP functionality and hidden video conference details.
-- Video conferencing and webinar facilities for virtual meetings and events, and hybrid in-person / virtual events.
-- Social messaging app to communicate in real time with the OWASP community.
-- Leaders have access to leaders@owasp.org - join using owasp.org email address.
+- Video conferencing and webinar facilities for virtual meetings and events, and hybrid in-person/virtual events.
+- Social messaging app to communicate in real-time with the OWASP community.
+- Leaders should join leaders@owasp.org using their owasp.org email address.
 - Assistance and resources are available through the [Chapter Committee](https://owasp.org/www-committee-chapter/) and other [OWASP Committees](https://owasp.org/committees/).
 - Event insurance covering chapter meetings.
 
-Services identical or like those provided by the foundation cannot be expensed without [prior approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107). Where possible, all chapters are encouraged to use a service that respects user privacy.
+Services identical or like those provided by the Foundation cannot be expensed without [prior approval](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/107). Where possible, all chapters are encouraged to use a service that respects user privacy.
 
-## Starting a New Chapter
+### Shared Services for Regional Branches
 
-There are currently two types of chapters you can start: city chapters and student chapters. Prospective chapter leaders should familiarize themselves with this policy and the draft [Chapter Handbook](https://owasp.org/www-committee-chapter/#div-resources_for_chapters) prior to submitting the form.
+Shared services provided by the Foundation will be pooled by the Regional Chapter and not provided directly to the Branches.
 
-- New chapters must be approved by the foundation, by submitting a request through [Contact Us](https://contact.owasp.org/).
-- After the new chapter is approved, the chapter leader must:
-  - Provide GitHub usernames in order to get admin access your chapter repository.
-  - Create new chapter pages within 30 days of GitHub access on the owasp.org website (see [Website Migration Information and Tutorial](https://owasp.org/migration/) for assistance).
-  - Log into their owasp.org email account within Google's defined time period, or they will need to log a support ticket via [Contact Us](https://contact.owasp.org/) to have a password recovery email sent to their registration email address.
+## Defining and Naming Chapters
 
-### Starting a City Chapter
+Chapter names should always aim to reduce confusion between the various chapter types to discover search engine. To that end, OWASP defines the following types of chapters and how they should be named:
+
+### Defining and Naming City chapters
 
 City chapters are the primary form of the OWASP chapter, with hundreds of chapters worldwide.
 
-- Approved city chapters are named "OWASP «city name»". City chapter names must not be a regional or country name unless the city name is the country name (e.g., Monaco).
-- Chapters shall be defined for a single city only; a new chapter may be denied approval if there is another chapter within 80 km (50 miles).
-- Chapter leaders must reside within 80 km (50 miles) of the chapter location.
-- Exceptions to distance rules may be approved on a case-by-case basis, for example where travel times between two geographically close chapters is excessive (defined as more than one hour).
+- Approved City chapters are named "OWASP «city name»". City chapter names must not be a regional or country name unless the city name is the country name (e.g., Monaco).
+- City chapters are defined for a single city only; a new chapter may be denied approval if another chapter is within 80 km (50 miles).
+- City chapter leaders must reside within 80 km (50 miles) of the chapter location.
 
-### Starting a Student Chapter
+Exceptions to distance rules may be approved on a case-by-case basis, for example, where travel times between two geographically close chapters are excessive (defined as more than one hour).
 
-Students and faculty of institutions of higher education can create student chapters.
+### Defining and Naming Student chapters
 
-- Student chapters are named “OWASP «institution name»” or where the institution has different campus locations, “OWASP «institution name» «campus»”
-- Student chapters are associated with one educational institution in a single geographic area. For example, each educational institution in a city is more than welcome to have their own student chapter, which is not the case for regular city chapters.
-- At least one leader must be a student, and at least one leader must be faculty from the institution.
-- Student chapters in a city with an active OWASP city chapter should make meaningful efforts to collaborate with the city chapter, and vice versa, where appropriate.
+Students and faculty of institutions of higher education can create Student chapters. As Student chapters are associated with an educational institution, there can be many Student chapters within a city, even cities with a City chapter.
+
+- Student chapters are named "OWASP «institution name»" or where the institution has different campus locations, "OWASP «institution name» «campus»"
+- Student chapters are associated with one educational institution in a single geographic area. For example, each educational institution in a city is more than welcome to have its own Student chapter, which is not the case for regular City chapters.
+- Student chapters must have at least one student leader and at least one leader from the institution's staff or faculty.
+
+Student chapters in a city with an active OWASP City chapter should make meaningful efforts to collaborate with the local City chapter, and vice versa, as appropriate.
+
+### Defining and Naming Regional chapters
+
+A Regional chapter represents a larger geographic area with a cohesive community that is not limited to a specific city. This might be a state/district/province, a whole country, or a commonly recognized geographic area.
+
+Regional chapters will have higher requirements and will require common consensus from the wider community in the area. (See "Starting a Regional chapter" for more details).
+
+Regional chapter names must be recognized by residents living in the region as commonly associated with the region.
+
+The existence of a Regional chapter does not conflict with the existence of a City chapter co-located in the same region. However, there are additional requirements.
+
+There is no requirement to become a Regional chapter, even if multiple cities wish to run a joint event, and it is completely optional.
+
+### Defining and Naming Regional branches
+
+A Regional chapter may optionally have one or more Branches in more remote locations. A Branch is not a full-fledged Chapter and is considered a local representative of the Regional Chapter. Branches will be approved and managed by the leaders of the Regional Chapter, supported by OWASP Staff.
+
+Branches should follow the naming rules of City chapters.
+
+## Chapter Leadership
+
+Chapter leaders serve as the main point of contact for their chapters and are responsible for ensuring the Chapter complies with all OWASP policies while fulfilling its mission and obligations.
+
+- Chapter leaders are not required to be members, but it is recommended to become one to promote membership.
+- Chapter leadership is open to all participants. Leadership is personal and not associated with any organization, company, or employer.
+- Each Chapter must have a minimum of 2 and a maximum of 5 Foundation-recognized, official leaders. In the event of a resignation, leadership transition, or new leadership being appointed, a chapter is allowed a grace period of up to 3 months from the event to comply.
+- A chapter leader can be a leader of only one Chapter.
+- Leaders will sign and return a leader's agreement within 30 days of receipt.
+- Each leader will annually confirm upon request within 30 days that they intend to continue volunteering as chapter leader.
+- Leaders are encouraged to transition or rotate every 2-3 years (minimum two years, maximum three years) to allow fresh leaders to step up and participate in the chapter operations. Leader selection is at the Chapter's discretion, provided all policies are followed.
+- If a chapter's leadership does not have consensus, fair and open elections should be administered with the support of OWASP staff and the [Chapter Committee](https://owasp.org/www-committee-chapter/).
+- Any changes in chapter leadership should be done by submitting a ticket with all information to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105) by one of the existing leaders. If the local chapter leadership is inactive, this request can be made by local chapter OWASP members.
+- If a leader needs to step down, they should submit a ticket to the [New Chapter/Leader Request](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105).
+- If a leader is no longer reasonably responsive and contributing to the Chapter, the remaining chapter leaders may petition the leader's removal in accordance with the dispute resolution process.
+
+### Student chapter Leadership
+
+Student chapters must adhere to City leadership as above, but in addition:
+
+- Student chapters must have at least one student leader and at least one leader from the institution's staff or faculty;
+- If a student graduates from the institution or a faculty member no longer works at the institution, they can no longer be a Student chapter leader.
+
+Student chapters do not need to meet minimum student leadership requirements during a semester or year breaks but must come back into compliance within 30 days of a new semester or year starting.
+
+### Regional chapter Leadership
+
+Regional chapter leaders have more requirements than City or Student chapters:
+
+- Regional Leadership management is the same as per City chapters;
+- Regional chapters must have at least three and usually a maximum of five Foundation-recognized leaders. If the region has more than five participating locations, it can have up to seven (7) leaders.
+
+### Regional branch Leadership
+
+A Branch must have at least one active Organizer and up to 3 official Organizers. Branch Organizers do not have to be Leaders but can additionally support the Regional Chapter as Leaders.
+
+Branch Organizers do not automatically become Leaders or Members but may also be Leaders of the Regional Chapter. Branch Organizers do not receive any benefits.
+
+Regional Chapter Leaders should attempt to find cost-effective ways to show appreciation for persistent Organizers. In addition, Regional Chapter Leaders are expected to mentor Branch Organizers in community management and organizing meetups.
+
+## Starting a new chapter
+
+Prospective chapter leaders should familiarize themselves with this policy and the draft [Chapter Handbook](https://owasp.org/www-committee-chapter/#div-resources_for_chapters) prior to submitting the form.
+
+- New chapters must be approved by the Foundation by submitting a request through [Contact Us](https://contact.owasp.org/).
+- After the new Chapter is approved, the chapter leader must:
+  - Provide GitHub usernames in order to get admin access to your chapter repository.
+  - Create new chapter pages within 30 days of GitHub access on the owasp.org website (see [Website Migration Information and Tutorial](https://owasp.org/migration/) for assistance).
+  - Log into their owasp.org email account within Google's defined time period, or they will need to log a support ticket via [Contact Us](https://contact.owasp.org/) to have a password recovery email sent to their registered email address.
+
+### Starting a City or Student chapter
+
+All the above requirements for starting a chapter must be met.
+
+### Starting a Regional chapter
+
+Regional Chapters will only be created with the approval of the Chapter Committee after confirming the below requirements (in particular the first three bullet points below).
+
+All of the following requirements must be met to start a new regional chapter.
+
+- All "Starting a New City chapter" requirements must be met;
+- Consensus on the creation of a new Regional chapter is required by at least three different City chapter leaders from within the region, each at least 80 km (50 miles) apart;
+- All City chapter leaders within the defined region must agree to the creation of the new Regional Chapter, and there must be no *dissenting* City chapter leaders within the region;
+- The new region chapter name must be recognized by residents living in the region as commonly associated with the region; and
+- If there are overlapping regions, the new Regional Chapter will be the smallest of the overlapping regions that incorporate all participating locations.
+
+Initial leadership must include the leaders from the initial consensus and from at least three different locations.
+
+Regional Chapters must perform a "health check" of the "Starting a Regional Chapter" requirements with the Chapters Committee at least once a year.
+
+### Starting a Regional branch
+
+Regional leaders can create and manage Regional branches.
+
+A Branch cannot exist independently without a managing Regional chapter. A Regional chapter can have multiple Branches. Branches differ from standard City chapters in the following ways:
+
+- Branches will not have their own page on the OWASP website but should be listed on the Regional Chapter's webpage.
+
+If the Regional Conference (as per B.3.b.(i) above) results in a net profit, the Regional Chapter may elect to provide a Meetup.com group or other shared service (under the regular OWASP account) for an active Branch at the Regional Chapter's own expense, if approved by the leaders of the Regional Chapter. This will be provided by OWASP Staff, on condition that the profits from the Regional Conference can cover the costs of the service. The costs of these Branch groups shall not be borne by the OWASP Foundation.
+
+Branches are managed solely by the Regional Chapter and do not directly require Staff involvement. Regional chapter Leaders are responsible for their Branch's meeting requirements, for their continued activities, and for mentoring their Branch Organizers as needed. This will be additionally monitored by the Chapter Committee on a yearly basis.
+
+If a Branch meets the standard requirements for a City chapter, they can opt to "graduate" to a full Chapter, as long as they continue to meet the requirements. However, while this should be encouraged, it is not mandatory, and they may continue as a Branch. If the Branch does become a Chapter, the Regional Chapter must continue to meet its requirements as well.
 
 ### Renaming a Chapter
 
-- Any chapter name changes must be approved by the foundation. A request for approval must be submitted through [Contact Us](https://contact.owasp.org/).
-
-### Regional Chapters
-
-Existing active regional chapters can continue to operate, as per the policy for city chapters, including access to foundation services, expenses, etc as detailed in this policy. Regional chapters hold no powers over any other chapter.
-
-Once the new supplemental regional chapter policy is created and approved by the board, this section will no longer be in effect, and existing regional chapters will be governed by the supplemental regional chapter policy.
-
-**Note: Starting new or re-activating inactive regional chapters will not be approved until the supplemental regional chapter policy comes into effect.**
-
-***Background rationale*** Regional chapters have never been defined by any prior policy, and they all operate differently with various levels of success. As there are at least 10 regional chapters, the regional model is actively being re-developed to be a sustainable model that promotes regional cooperation, activity, leadership, accountability, and transparency. Existing regional chapter leaders are encouraged to work with the [Chapter Committee](https://owasp.org/www-committee-chapter/) to define the regional chapter model.
+- Any chapter name changes must be approved by the Foundation. A request for approval must be submitted through [Contact Us](https://contact.owasp.org/).
 
 ## Inactive Chapters
 
@@ -147,26 +245,58 @@ The OWASP Foundation aims to provide continuity for OWASP chapter members. The f
 
 - An inactive OWASP chapter is a chapter that has not met [minimum activity requirements](#meetings-and-activity-requirements) defined in this policy.
 - An inactive chapter must either be reactivated or dissolved.
-- The OWASP Foundation will revoke the inactive chapter leadership and refer the inactive chapter to the [Chapter Committee](https://owasp.org/www-committee-chapter/) to help find fresh leadership or to run elections to elect new leadership.
-- Use this form to [reactivate a chapter](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105). Where an inactive chapter does not hold a meeting within 90 days of being reactivated, or new leadership could not be appointed within 90 days of failing to meet activity targets, the [Chapter Committee](https://owasp.org/www-committee-chapter/) will discuss the inactive chapter and vote on it. If agreed, the chapter will be dissolved by the OWASP Foundation.
+- The OWASP Foundation will revoke the inactive chapter leadership and refer the inactive Chapter to the [Chapter Committee](https://owasp.org/www-committee-chapter/) to help find fresh leadership or to run elections to elect new leadership.
+- Use this form to [reactivate a chapter](https://owasporg.atlassian.net/servicedesk/customer/portal/8/group/20/create/105). Where an inactive chapter does not hold a meeting within 90 days of being reactivated, or new leadership could not be appointed within 90 days of failing to meet activity targets, the [Chapter Committee](https://owasp.org/www-committee-chapter/) will discuss the inactive Chapter and vote on it. If agreed, the Chapter will be dissolved by the OWASP Foundation.
+
+## Regional chapter conflict resolution
+
+A Regional Chapter can exist with additional City Chapters that overlap in the same region, in the following circumstances only. In the case of overlapping Regional Chapter and City Chapter, these will be independent of each other and will not have control or influence over the other. In any unresolved event, the Chapters Committee will be the arbiters and provide a final decision.
+
+### Creating a new Regional Chapter where City Chapters exist
+
+New Regional Chapters may only be created upon the approval of the Chapters Committee. If the proposed Regional Chapter meets the requirements set out in "Starting a new Regional chapter," the staff will refer the Regional Chapter leaders to the Chapters Committee.
+
+The Chapters Committee will review the Regional Chapter's proposal and discuss with relevant City Chapters as needed. The Chapters Committee will vote on the proposed Regional Chapter at the next Committee meeting after the review is completed.
+
+In order to create a new Regional Chapter, there must be no existing chapters or active community leaders in the same region that object to the creation of this Regional Chapter, e.g., leaders of a City Chapter in the region claims that there is no regional community, or that the region does not include those cities.
+
+If there are existing City Chapters in the same region, and the leaders of said chapters concur with the Regional Chapter's claims AND agree that the Regional Chapter can coexist, then the overlapping Regional Chapter can be created.
+
+The City Chapter may opt to join the Regional Chapter as a Participating Chapter, downgrade to a Branch, or remain an independent overlapping City Chapter (with no connection to the Regional Chapter).
+
+### Creating a new City Chapter within the region of an overlapping Regional Chapter
+
+Where all requirements are met for starting a new City chapter, and the proposed City chapter lies within the defined region of an existing Regional chapter that meets all regional chapter requirements (including consensus), the requesting City Chapter leaders will first be referred to the leaders of the overlapping Regional Chapter to discuss mutually beneficial solutions, such as organizing an additional Branch of the Regional Chapter. The Chapters Committee will mediate as necessary.
+
+However, if such a solution cannot be mutually agreed upon, the Regional Chapter will not have the power to block the City Chapter from being created. The new City Chapter will be created and exist independently of the Regional Chapter, with no effect on the Regional Chapter and no influence between the two.
+
+The above will only apply if none of the Regional Chapter Leaders are from the same city as the proposed City Chapter. If leaders of the Regional Chapter reside/work in the same city in which the City Chapter is wanted to be created, and there are multiple activities held in the city, they will be considered the leaders of the City Chapter and will independently reach a decision regarding the creation of this City Chapter. The Chapter Committee will interpret this as a situation wherein someone wants to create a new City Chapter in the same city where an active City Chapter exists.
+
+Note that both the City Chapter and the Regional Chapter must continue to meet their respective requirements. In particular, the Regional Chapter must still retain consensus from other community members, excluding the city wherein the City chapter exists. The Regional Chapter must have consensus from leaders in at least three cities, not including the one where the City Chapter is created.
 
 ## Finances, Oversight, and Transparency
 
-Chapters are overseen on an operational basis by the [Chapter Committee](https://owasp.org/www-committee-chapter/), the OWASP Foundation staff, and, ultimately, the OWASP Board of Directors. If the Chapter Committee, foundation staff, or board of directors determines that a leader has not complied with this policy, despite support and outreach, leadership may be revoked, suspended, or another action taken. Additionally, OWASP administrative access (including the leader's owasp.org email address) may immediately be revoked.
+Chapters are overseen on an operational basis by the [Chapter Committee](https://owasp.org/www-committee-chapter/), the OWASP Foundation staff, and, ultimately, the OWASP Board of Directors. Leaders who have not complied with this policy, leadership privileges may be revoked, suspended, or another action taken. The OWASP Foundation may revoke the leader's access to all OWASP accounts, shared services, including the leader's email, and any privileged functionality upon notification by the Chapter Committee, the OWASP Foundation, or Board of Directors of a breach of this policy.
 
 ### Code of Conduct and Other Relevant Policies
 
-All leaders must follow and adhere to all OWASP Foundation [policies and procedures](https://owasp.org/www-policy/), which are in a central repository. As a US-based 501 (c)(3) non-profit organization, OWASP must follow specific financial and legal guidelines that can change from time to time.
+All leaders must follow and adhere to the latest published OWASP Foundation [policies and procedures](https://owasp.org/www-policy/). As a US-based 501 (c)(3) non-profit organization, OWASP must follow specific financial and legal guidelines that can change from time to time.
 
 Chapters operate with a great deal of freedom; however, chapters must abide by the latest approved [Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct), [Foundation Bylaws](https://owasp.org/www-policy/legal/bylaws), and these [policies and procedures](https://owasp.org/www-policy/). Copies of older versions are not relevant.
 
 ### Privacy
 
-OWASP membership and participation in chapter meetings are subject to locally applicable data protection regulations (for instance, see [GDPR](https://gdpr.eu)). Where conflicting local regulations exist, the most restrictive should be observed. All chapter meetings must comply to [OECD principles](https://www.oecd.org/sti/ieconomy/oecd_privacy_framework.pdf); the Collection Limitation Principle applies to all activities where personal information of participants is needed. Chapter leaders are not permitted to share member lists, event attendees, or private information with third parties except where operationally necessary and only after informing relevant parties with opt-in acceptance. Chapters should, where possible and not otherwise required by local legislation or compliance requirements, adopt a data minimization approach, and delete data that is no longer necessary.
+OWASP membership and participation in chapter meetings are subject to locally applicable data protection regulations (for instance, see [GDPR](https://gdpr.eu)). Where conflicting local regulations exist, Chapter leaders should observe the most restrictive. All chapter meetings must comply with [OECD principles](https://www.oecd.org/sti/ieconomy/oecd_privacy_framework.pdf); the Collection Limitation Principle applies to all activities where personal information of participants is needed. Chapter leaders are not permitted to share member lists, event attendees, or private information with third parties except where operationally necessary and only after informing relevant parties with opt-in acceptance. Chapters should, where possible and not otherwise required by local legislation or compliance requirements, adopt a data minimization approach and delete data that is no longer necessary.
 
 ### Submitting Expenses
 
-Chapter related expenses incurred while holding a chapter meeting within the geographic area of the chapter itself must comply with the [expense policy](https://owasp.org/www-policy/operational/expense-reimbursement) and must be submitted within 60 days.
+Chapter-related expenses incurred while holding a chapter meeting within the Chapter's geographic area must comply with the [expense policy](https://owasp.org/www-policy/operational/expense-reimbursement) and must be submitted within 60 days. The OWASP Foundation cannot reimburse chapter expenses for events or activities outside the Chapter's geographic area without prior approval.
+
+The OWASP Foundation will manage regional chapter expenses the same way as City chapter expenses.
+
+#### No Expense Access to Regional branches
+
+Regional branches are not authorized to submit expenses directly. Regional branches must submit expenses via their Regional chapter leadership. Regional chapter leaders must approve regional branch expenses.
 
 ### Memberships
 
@@ -174,27 +304,34 @@ Members are the lifeblood of chapters. Memberships must be processed per the [me
 
 ### Donations
 
-All donations must comply with and be processed per the foundation [donation policy](https://owasp.org/www-policy/operational/donations).
+Donations will be processed per the [donation policy](https://owasp.org/www-policy/operational/donations). Direct donations or sponsorships of local chapters are not permitted.
 
-### Paid Events
+### Free and Paid Events
 
-Chapters wishing to create paid events like training and workshops should review the [events policy](https://owasp.org/www-policy/operational/events) for more information. Payments for training, workshops, and other events will be made in accordance with the [expense policy](https://owasp.org/www-policy/operational/expense-reimbursement).
+The OWASP Foundation will process free chapter training events, activities, workshops, and other local events not covered by the Events policy per the [expense policy](https://owasp.org/www-policy/operational/expense-reimbursement). Expense pre-approval limits and leader co-approvals apply.
+
+The OWASP Foundation will process paid local or AppSec Days (formerly regional) events. These events are pre-approved in OCMS per the [Events policy](https://owasp.org/www-policy/operational/events), only if the Event policy applies. The Events policy does not apply to most free chapter meetings, local activities, or minor events. If in doubt, please [raise a ticket](https://contact.owasp.org).
+
+For more information, leaders should review and follow the following policies:
+
+[Expenses policy](https://owasp.org/www-policy/operational/expense-reimbursement)
+[Events policy](https://owasp.org/www-policy/operational/events).
 
 ### Chapters are Not Legal Entities
 
-Chapters, projects, and groups are not legal entities and are organized under the OWASP Foundation's authority.
+The OWASP Foundation has authority over all OWASP chapters, projects, committees, and events. They are not separate legal entities.
 
 ### Finances are via OWASP Foundation Only
 
-As chapters are not legal entities, all membership dues and funds must be processed through the foundation for transparency, the US not-for-profit laws, regulatory, and tax compliance reasons. Chapters are not permitted to hold any bank accounts, independent insurance, have an independent donation mechanism, or use any funds transfer mechanisms to store financial value such as gift cards, PayPal or Venmo, or any other banking or financial instruments.
+Chapters are not legal entities. The OWASP Foundation will process all membership dues and funds for transparency, US not-for-profit laws, regulations, and tax compliance. Chapters are not permitted to hold or use independent bank accounts, insurance, donation mechanisms. Chapters cannot ex[ense or use funds transfer mechanisms to store financial value such as gift cards, PayPal or Venmo, or other banking or financial instruments.
 
 ### Signing Authority
 
-Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory2). As non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. All such agreements should be referred to the OWASP Foundation for pre-approval and possible signing.
+Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory2). As for non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. Chapter leaders should refer all such agreements to the OWASP Foundation for pre-approval and possible signing.
 
 ### Supporters and Bartering Arrangements
 
-Chapters are encouraged to obtain local chapter supporters via bartering arrangements (i.e. services, event spaces, or food and beverages are paid for by a chapter supporter) and donations via the OWASP website. Chapters can define levels and benefits of local Chapter Supporters, including logos on introduction slides and the Chapter home page. Any contractual agreement, bartering arrangement, or financial transaction must be registered and processed by the Foundation through our [service desk](https://contact.owasp.org/)
+Chapters are encouraged to obtain local chapter supporters via bartering arrangements (i.e., services, event spaces, or food and beverages are paid for by a chapter supporter) and donations via the OWASP website. Chapters can define the levels and benefits of local Chapter Supporters, including logos on the introduction slides and the Chapter home page. Any contractual agreement, bartering arrangement, or financial transaction must be registered and processed by the Foundation through our [service desk](https://contact.owasp.org/)
 
 ### Disputes
 
@@ -204,24 +341,25 @@ Chapter members and leaders can use the following policies and reporting mechani
 
 - [Conflict resolution policy](https://owasp.org/www-policy/operational/conflict-resolution) for most disputes between participants.
 - [Code of Conduct](https://owasp.org/www-policy/operational/code-of-conduct) policy for ethical or conduct breaches.
-- The [OWASP Chapter Committee](https://owasp.org/www-committee-chapter/) is the first point of escalation.
+- The [OWASP Chapter Committee](https://owasp.org/www-committee-chapter/) is the first escalation point.
   - The [Executive Director](https://owasp.org/corporate/) as the second point of escalation, and finally.
   - the [Global Board](https://owasp.org/www-board/).
-- To report severe violations of policy, financial, or fiduciary misconduct, please refer to the [whistleblower and anti-retaliation policy](https://owasp.org/www-policy/operational/whistleblower).
+
+To report severe policy, financial, or fiduciary misconduct violations, please refer to the [whistleblower and anti-retaliation policy](https://owasp.org/www-policy/operational/whistleblower).
 
 ### Sanctioned Countries and Leaders
 
-OWASP must comply with international laws and regulations, including international sanctions. Sanctions take many forms and are often limited in scope to access to specific intellectual property, organizations, governments, and/or individuals.
+OWASP must comply with international laws and regulations, including international sanctions. Sanctions take many forms and are often limited in scope to access specific intellectual property, organizations, governments, or individuals.
 
-From time to time, the Executive Director and Community Manager will review sanctions from the EU, USA, and anywhere else the foundation has an operating entity, and apply the following policies.
+From time to time, the Executive Director and Community Manager will review sanctions from the EU, USA, and anywhere else the Foundation has an operating entity and apply the following policies.
 
-Until sanctions are lifted and where not complying with or breaching sanctions would cause the OWASP Foundation to be subject to fines, civil or criminal liability, the following policies will be applied:
+The OWASP Foundation must comply with US Government or EU sanctions. Breaching sanctions may cause the OWASP Foundation to be subject to fines, civil or criminal liability. The following policies apply against sanctioned individuals, entities, or countries to manage this risk:
 
 a) New chapters cannot be formed.
 b) Existing chapters may be disbanded or made independent of the Foundation depending on the nature of the sanctions.
-c) Leaders and members who are sanctioned individuals will be removed from any leadership positions, and any membership fees refunded, including Lifetime membership.
-d) Access to OWASP materials are free and open-source, and can be obtained through many means, including OWASP shared cloud platforms. For the purposes of curtailing access or prohibiting the "export" of such freely available information, OWASP relies solely upon the technical controls in place by our shared cloud platforms, which share the same sanction controls as the OWASP Foundation. The Foundation has no control over these technical controls, and the Foundation will not subvert these technical controls to allow access in sanctioned countries.
+c) For sanctioned leaders and members, the OWASP Foundation will remove individuals from any leadership positions and any membership fees refunded, including Lifetime membership.
+d) Access to OWASP materials is free and open-source, and can be obtained through any means, including OWASP shared cloud platforms. OWASP relies solely upon the technical controls in place by our shared cloud platforms to prevent access or prohibit the "export" of such freely available information. The OWASP Foundation has no control over these technical controls. The OWASP Foundation will not subvert these technical controls to allow access in sanctioned countries.
 
-The Executive Director and/or Community Manager will inform the OWASP Global Board and Chapter Committee of any changes to sanctioned chapters, leadership, or access.
+The OWASP Foundation will inform the OWASP Global Board and Chapter Committee of any sanctioned chapters, leadership, or access changes.
 
-The Community Manager will review the list of sanctioned chapters and leaders periodically to determine if the Foundation can restore the chapter, leadership, and membership.
+The OWASP Foundation will periodically review the list of sanctioned chapters and leaders to determine if the Foundation can restore the Chapter, leadership, and membership.


### PR DESCRIPTION
Merged the Chapter Committee's regional chapter policy. This doesn't take into account association management platforms, so will need a further change to make it go. 

Minor nips and tucks to the existing policy fixing the issues with student chapter breaks and activity. Additionally, removed old staff titles, and spell / grammar checked (part way done).