### PR TITLE
Fix signing authority for members, leaders, and staff

### DIFF
--- a/draft-prepublish/chapters.md
+++ b/draft-prepublish/chapters.md
@@ -345,7 +345,7 @@ Chapters are not legal entities. The OWASP Foundation will process all membershi
 
 ### Signing Authority
 
-Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory2). As for non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. Chapter leaders should refer all such contracts to the OWASP Foundation for pre-approval and subsequent signing.
+Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory). As for non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. Chapter leaders should refer all such contracts to the OWASP Foundation for pre-approval and subsequent signing.
 
 ### Supporters and Bartering Arrangements
 

--- a/operational/chapters.md
+++ b/operational/chapters.md
@@ -190,7 +190,7 @@ As chapters are not legal entities, all membership dues and funds must be proces
 
 ### Signing Authority
 
-Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory2). As non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. All such agreements should be referred to the OWASP Foundation for pre-approval and possible signing.
+Chapters operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory). As non-legal entities, chapters leaders and members of chapters cannot sign contracts or enter into agreements with commercial organizations. All such agreements should be referred to the OWASP Foundation for pre-approval and possible signing.
 
 ### Supporters and Bartering Arrangements
 

--- a/operational/expense-reimbursement.md
+++ b/operational/expense-reimbursement.md
@@ -41,7 +41,7 @@ Expense reimbursement requests, along with receipts or invoices for each expense
 - Reimbursements are net banking fees and any applicable taxes.
 - Reimbursements will be made within 30 days, provided the information submitted is approved, complete, and accurate.
 
-Approvals for reimbursements shall follow the [signatory limits](/www-policy/operational/signatory2) of the OWASP Foundation.
+Approvals for reimbursements shall follow the [signatory limits](/www-policy/operational/signatory) of the OWASP Foundation.
 
 ***Please note all reimbursement request information, except payment instructions, will be shared publicly in various accounting reports, and by submitting an expense reimbursement, you agree to that disclosure.***
 
@@ -63,11 +63,11 @@ Expenses are available to all Chapters, Projects, Committees, Foundation staff, 
 
 The Board funds the expense pool via the annual budget at their sole discretion, topped up by donations, event profit shares, and directed sponsorships. The OWASP Corporate Membership program may in the future include the ability to help fund the expenses pool by directing a portion of the membership fee to selected or all chapters, projects, and committees.
 
-The expense pool has a monthly spend limit. If the monthly limit is exceeded, the Executive Director, Treasurer, or Global Board may choose to bring forward future months or top up the expense pool at their discretion per [signatory limits](https://owasp.org/www-policy/operational/signatory2).
+The expense pool has a monthly spend limit. If the monthly limit is exceeded, the Executive Director, Treasurer, or Global Board may choose to bring forward future months or top up the expense pool at their discretion per [signatory limits](https://owasp.org/www-policy/operational/signatory).
 
 Awards and Scholarships will be funded per the [Awards and Scholarships Policy](https://owasp.org/www-policy/operational/awards-and-scholarships) via specific sponsorships, donations, or grants and not from the expense pool. Unfunded Awards or Scholarships with no balance cannot reimburse expenses. Awards and Scholarships are not transferrable, and if not used for the nominated purpose, funds are returned to the Expenses pool to further our mission in other ways.
 
-Events can use the reimbursement processes defined below but will be funded via their budget, profit, and loss, governed by the [Events Policy](https://owasp.org/www-policy/operational/events). The event expenses will be drawn from the seed funds and income, not the general expense pool. Seeding for events may be funded by the Executive Director or Board at their discretion and within [signatory limits](https://owasp.org/www-policy/operational/signatory2) per the Events Policy.
+Events can use the reimbursement processes defined below but will be funded via their budget, profit, and loss, governed by the [Events Policy](https://owasp.org/www-policy/operational/events). The event expenses will be drawn from the seed funds and income, not the general expense pool. Seeding for events may be funded by the Executive Director or Board at their discretion and within [signatory limits](https://owasp.org/www-policy/operational/signatory) per the Events Policy.
 <!-- TODO -->
 <!-- Reword - not sure what the intent is here -->
 Grants will be funded through donations, sponsorship, or Board seeding. Expenses from grants will be drawn from the grant until fully drawn down, per the [Grants Policy](https://owasp.org/www-policy/operational/grants). Unfunded grants or grants with no balance cannot reimburse expenses.

--- a/operational/grants.md
+++ b/operational/grants.md
@@ -141,7 +141,7 @@ Grants are subject to being audited by the OWASP Foundation, including validatin
 
 ### Exemptions to Policy
 
-Exemptions to this policy can be granted by the OWASP Executive Director and documented in the application. Exemptions requiring changes to our bylaws, policies, or non-compliant funding exceeding the Executive Director’s [signing authority](/www-policy/operational/signatory2.md), require an affirmative Board vote.
+Exemptions to this policy can be granted by the OWASP Executive Director and documented in the application. Exemptions requiring changes to our bylaws, policies, or non-compliant funding exceeding the Executive Director’s [signing authority](/www-policy/operational/signatory.md), require an affirmative Board vote.
 
 ### Conflicts of Interest
 

--- a/operational/projects.md
+++ b/operational/projects.md
@@ -146,7 +146,7 @@ As projects are not legal entities, all membership dues and funds must be proces
 
 ### Signing Authority
 
-Projects operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory2). As non-legal entities, project leaders and members of projects cannot sign contracts or enter into agreements with commercial organizations. All such agreements should be referred to the OWASP Foundation for pre-approval and possible signing.
+Projects operate under the aegis and policies of the OWASP Foundation and are subject to the [OWASP signing policy](https://owasp.org/www-policy/operational/signatory). As non-legal entities, project leaders and members of projects cannot sign contracts or enter into agreements with commercial organizations. All such agreements should be referred to the OWASP Foundation for pre-approval and possible signing.
 
 ### Supporters and Bartering Arrangements
 

--- a/operational/signatory.md
+++ b/operational/signatory.md
@@ -1,19 +1,47 @@
 ---
 
-title: Signatory
+title: Signatory (Draft WIP)
 layout: col-document
 document: Rules of Procedure
 tags: Rules of Procedure
 
 ---
 
-Adopted by the Board of Directors 24-Mar-2020, altered signing authority February 23, 2021
+{% include draft-notice.html %}
 
 ## Financial and Spending Authority
 
+### Members
+
+Financial Members have access to the Expense policy. All expenses are subject to the Expense policy, and may not necessarily be approved by the OWASP Foundation. If in doubt, please submit a ticket for expense pre-approval.
+
+- $0 - $250 requires a single leader to co-approve expenses
+- $250 and above require a two leaders to co-approve expenses
+
+Members may not enter into or sign contracts or agreements. All funds must be processed through the OWASP Foundation or one of its entities.
+
+### Leaders
+
+Leaders have access to the Expense policy. All expenses are subject to the Expense policy, and may not necessarily be approved by the OWASP Foundation. If in doubt, please submit a ticket for expense pre-approval.
+
+- $0 - $250 Leaders are pre-approved to incur expenses without a second approver
+- $250 and above require a second leader to co-approve expenses
+
+Leaders may not enter into or sign contracts or agreements. All funds must be processed through the OWASP Foundation or one of its entities.
+
+### Staff
+
+In the course of ordinary business, staff are required to approve various expenses or costs associated with their position, such as organizing a meeting, providing cloud hosting, or providing equipment.
+
+- $0 - $1,000 Staff members can sign and approve without second approver
+- $1,000 to $10,000 Staff Member and Executive Director or Treasurer
+- $10,000 or more must be signed by Executive Director and Treasurer
+
+Staff may not sign contracts or agreements worth more than $1,000 USD. All funds must be processed through the OWASP Foundation or one of its entities.
+
 ### Executive Director
 
-The Executive Director, subject to the quarterly total spending as set forth in the Quarterly Breakdown of the Annual Budget (Quarterly Plan) approved by the Board of Directors (Board) and exercising all necessary due diligence and care, is individually authorized by this delegation to obligate the funds of the OWASP Foundation (OWASP), to execute agreements reflecting those obligations, and to further delegate this authority as deemed appropriate, up to and including the limits set forth below per transaction, such limit shall include integrated or related transactions.
+The Executive Director, subject to the Annual Budget approved by the Board of Directors (Board) and exercising all necessary due diligence and care, is individually authorized by this delegation to obligate the funds of the OWASP Foundation (OWASP), to execute agreements reflecting those obligations, and to further delegate this authority as deemed appropriate, up to and including the limits set forth below per transaction, such limit shall include integrated or related transactions.
 
 Budgeted or Discretionary per transaction (or related transactions), grant making, awards and scholarships, expense approvals, legally binding contractual arrangements, and purchasing assets:
 
@@ -26,7 +54,7 @@ Signing authority:
 - Transferring funds between and managing OWASP bank accounts and other financial accounts $ 250,000
 - Budgeted General Operational Spending (including but not limited to, payroll, expenses, and accounts payable), $ 500,000
 
-Any spending which exceeds the Quarterly Plan by more than 10%, must be approved by the Board of Directors.
+Any spending which exceeds the approved Annual Budget by more than 10%, must be approved by the Board of Directors.
 
 ### Chief Financial Officer
 


### PR DESCRIPTION
Also, remove last traces of the previous quarterly plan requirement, in favor of a simple $10k limit.