### PR TITLE
Create OWASP Travel policy

### DIFF
--- a/operational/travel.md
+++ b/operational/travel.md
@@ -1,0 +1,65 @@
+---
+
+title: Travel Policy
+layout: col-document
+document: Rules of Procedure
+tags: Rules of Procedure
+notice: 2023-02-15
+
+---
+
+{% include draft-notice.html %}
+
+## TRAVEL POLICY
+
+### Applicability
+
+All travel on behalf of OWASP, including travel for conferences, meetings, and other business-related activities, is subject to this policy and pre-approval prior to booking or undertaking travel. This policy applies to all OWASP team members, including employees, Board members, invited speakers, contractors, and volunteers.
+
+### Travel expenses
+
+OWASP will reimburse all actual and reasonable business-related expenses incurred by team members in performing their job duties according to the following guidelines:
+
+### Documentation Requirements
+
+You are required to provide a daily record of expenses, which shows the date, business location (city and state), and business purpose. Receipts must be attached for all reimbursable business expenses, including but not limited to individual meals, entertainment, lodging, auto rental, cab fare, and commercial travel.
+
+All receipts must be submitted within 30 days of the date of the expense. Failure to submit receipts within 30 days may result in the denial of reimbursement. Receipts must be submitted via Jira ticket for processing.
+
+### Lodging
+
+In certain cities and locales, OWASP may have negotiated discounted room rates with specific hotels. You should make every effort to utilize lodging in locations where these arrangements exist. When a guaranteed reservation must be changed, every reasonable effort should be made to cancel the reservation on a timely basis to avoid additional fees.
+
+The cost of overnight lodging (room rate and tax only) will be reimbursed to the traveler if the authorized travel is 45 miles or more from the traveler's home or primary worksite. Exceptions to this restriction may be approved in writing by the Executive Director or by the OWASP Treasurer.
+
+OWASP will reimburse lodging expenses at reasonable, single occupancy or standard business room rates. When the hotel or motel is the conference or convention site, reimbursement will be limited to the conference rate.
+
+Only single room rates are authorized for payment or reimbursement unless the second party is representing the Foundation in an authorized capacity. If the lodging receipt shows more than a single occupancy, the single room rate must be noted. If reimbursement for more than the single room rate is requested, the name of the second person must be included.
+
+### Transportation
+
+Every effort should be made to use the lowest-priced transportation available. Reimbursement will be made for the following modes of transportation:
+
+- Commercial airline, coach, or train travel will only be reimbursed for economy class unless approved by management for a medical exemption (proof is required)
+- Negotiated discount rates for auto rental may be available. You should utilize these arrangements where possible.
+- Personal auto used for business will be reimbursed at the current IRS mileage rate; however, the total amount for mileage must not exceed the economy class airfare for the same trip. The mileage reimbursement rate covers all vehicle expenses, including gas, insurance, and depreciation.
+
+Local commuting costs between a team member’s residence and work location are not allowable business expenses. If the distance between your residence and place of departure is further than the distance between your residence and work location, the excess mileage is an allowed expense.
+
+### Meals & Incidentals
+
+Per diem allowances are reimbursable for in-state overnight travel that is 70 km (45 miles) or more from the traveler's home or primary worksite.
+
+Per diem allowances are applicable for all out-of-state travel that is 70 km (45 miles) or more from the traveler's home or primary worksite.
+
+OWASP per diem rates are based on the U.S. General Services Administration Guidelines, which vary by city location. In addition to meals, these rates include incidental expenses such as laundry, dry cleaning, and service tips (e.g., housekeeping or porter tips). Incidental expenses, unless specifically cited in this policy, will not be reimbursed.
+
+Per diem reimbursements are based on departure and return times over the entire 24-hour day and are prorated accordingly.
+
+If a free meal is served on the plane, included in a conference registration fee, built into the standard, single hotel room rate, or replaced by a legitimate business meal, the per diem allowance for that meal may not be claimed.
+
+Receipts are not required for per diem allowances. Per diem allowances are reimbursed after the trip is completed.
+
+### Parking and Highway Tolls
+
+All parking expenses and highway tolls related to business travel will be reimbursed.


### PR DESCRIPTION
Main text is from the staff handbook, which will also be updated.

Includes motion passed on 14th February 2023 to restrict travel to economy only fares.

