### PR TITLE
Create Travel Policy

### DIFF
--- a/operational/travel.md
+++ b/operational/travel.md
@@ -11,6 +11,7 @@ notice: 2025-04-28
 {% include draft-notice.html %}
 
 OWASP is a global nonprofit organization, with volunteers all over the world. As such, travel is occasionally necessary. Where possible, local volunteers or speakers should be chosen to minimize travel expenses. OWASP will not approve travel if there are local volunteers nearby. Please seek out local volunteers before proceeding with a pre-approval travel request. Travel covered by this policy is needs-based, and is not guaranteed simply because the traveler might be an OWASP leader, chosen to speak at an OWASP event, or a participant at a regulatory meeting. Travel pre-approval is more likely if there are budgeted funds available or through fundraising on behalf of the request.
+
 ## Scope
 
 This policy covers Board, volunteer, and participant travel for events, projects, or chapters, such as speakers or invited keynote speakers, project workshops or summits, chapter speakers, and any other pre-approved travel purpose, such as representing OWASP at regulatory bodies or at co-marketing events. All Board and volunteer travel must be pre-approved by the OWASP Foundation.
@@ -99,7 +100,7 @@ Large bulky gifts are unlikely to be welcomed by recipients as they will struggl
 
 OWASP does not provide cash advances for travel. Regular OWASP travelers should obtain a widely accepted credit card. Interest charges and fees are considered personal expenses and, therefore, will not be reimbursed.
 
-## Pre-approval process
+## Pre-Approval Process
 
 To gain pre-approval for your travel is via creating a Jira ticket in the Payment Approval and Request Service Desk:
 
@@ -109,7 +110,7 @@ To gain pre-approval for your travel is via creating a Jira ticket in the Paymen
 
 Once approved, please make your bookings. Small variances between your pre-approval amount and the final ticket price are acceptable. If your booked travel costs are more than about 5% more than the pre-approval, the lesser of the two amounts will be reimbursed, so book promptly once approved. Approval may take up to three business days, and prices vary. Plan your travel early.
 
-## Claiming your travel expenses
+## Claiming Your Travel Expenses
 
 To claim your travel expenses, within 30 days of your return from the trip, please create a Jira ticket in the Funding project \> Payment Approval Service Desk, and choose one of the following:
 
@@ -119,6 +120,6 @@ To claim your travel expenses, within 30 days of your return from the trip, plea
 
 Please include the pre-approval ticket number in your expense claim to ensure reimbursement. If you fail to submit your expense claim within 30 days of your return, your expense claim may be denied. All necessary details and receipts must be submitted to avoid delays in reimbursement.
 
-## Travel assistance
+## Travel Assistance
 
 To help perform our mission, if you need travel assistance OWASP might be able to help by paying for your flights and accommodation, or providing a scholarship or grant for qualified individuals, such as students, speakers, trainers, leaders, and Board members. Due to limited funds, please note this when you apply for pre-approval (see above). We may not be able to help you, so please apply for travel assistance as early as you can.

--- a/operational/travel.md
+++ b/operational/travel.md
@@ -1,0 +1,126 @@
+---
+
+title: Board, Volunteer, and Participant Travel Policy (Draft WIP)
+layout: col-document
+document: Rules of Procedure
+tags: Rules of Procedure
+notice: 2025-04-28
+
+---
+
+{% include draft-notice.html %}
+
+OWASP is a global nonprofit organization, with volunteers all over the world. As such, travel is occasionally necessary. Where possible, local volunteers or speakers should be chosen to minimize travel expenses. OWASP will not approve travel if there are local volunteers nearby. Please seek out local volunteers before proceeding with a pre-approval travel request. Travel covered by this policy is needs based, and is not guaranteed simply because the traveler might be an OWASP leader, chosen to speak at an OWASP event, or a participant at a regulatory meeting. Travel pre-approval is more likely if there are budgeted funds available or through fundraising on behalf of the request.
+
+## Scope
+
+This policy covers Board, volunteer, and participant travel for events, projects, or chapters, such as speakers or invited keynote speakers, project workshops or summits, chapter speakers, and any other pre-approved travel purpose, such as representing OWASP at regulatory bodies or at co-marketing events. All Board and volunteer travel must be pre-approved by the OWASP Foundation.
+
+Staff travel is covered by the Staff Handbook, and must be pre-approved by the Executive Director.
+
+## Coverage
+
+OWASP will reimburse actual and reasonable OWASP-related expenses incurred for pre-approved travel to perform mission-related activities.
+
+- **Covered individuals**. Board members, invited keynote speakers, participants, and volunteers are eligible for approved travel.
+- **Covered costs**. OWASP only reimburses for necessary and pre-approved travel expenses as defined in this policy.
+- **Covered dates**. OWASP only permits reimbursements for necessary and pre-approved travel expenses and dates. Travel expenses outside the approved travel reason and dates are not OWASP-related and won't be reimbursed.
+
+## Documentation Requirements
+
+Provide a daily expense record showing the date, location, and purpose. Attach receipts for all reimbursable expenses, including meals, entertainment, lodging, car rental, cab fare, and travel.
+
+OWASP requires the use of Jira as an expense management system to record receipts and process expenses. No reimbursement will occur outside of Jira. Payment will be made only through BILL.com.
+
+Your reimbursement may incur fees by your bank which OWASP cannot and will not cover, as they are not within OWASP’s control.
+
+## Lodging
+
+OWASP may have negotiated discounted room rates with specific hotels, such as hotel room blocks. You should make every effort to utilize lodging in locations where these arrangements exist. To avoid extra fees, cancel guaranteed reservations promptly when changes are necessary.
+
+Overnight lodging costs (room rate and tax) are reimbursable if travel is 80 kilometers (or 50 miles) or more from home. Exceptions to this restriction may be granted in writing by either the Executive Director or the Treasurer.
+
+OWASP will reimburse lodging expenses at reasonable, single occupancy or standard business room rates. Reimbursement at conference sites is limited to the conference rate.
+
+Payment or reimbursement will be authorized solely for single room rates unless the additional occupant represents the Foundation in an official capacity. If the lodging receipt indicates multiple occupants, note the single room rate. Provide the name of the second person if requesting reimbursement above the single room rate.
+
+## Transportation
+
+Use the most cost-effective transportation possible. The following modes of transportation will be eligible for reimbursement:
+
+- Reimbursement for commercial airline, train, or bus travel will be limited to economy class unless prior approval is obtained from the Executive Director. Charters, private jet, or helicopter travel is not permitted.  
+- If a booking is more than $2000 USD, the booking must be a refundable airfare booking type to avoid losses or unusable "refunds," and not rely upon travel insurance for the refund.  
+- OWASP will reimburse the lowest fare that includes your checked baggage, whether that is a basic fare with paid luggage included, or a higher fare class with included luggage allowances. When submitting the expense, please justify your fare class selection based upon this criterion.  
+- If two separate one-way airfares need to be reimbursed, such as for personal travel before or after the official travel purpose, OWASP will pay the lowest of either two one way fares or a return ticket. Please provide quotes or both options during pre-approval.  
+- Premium economy is only permissible for **international** travel with a total flight duration of over 6 hours total duration. All other travel is economy class travel. The Executive Director can make exceptions in case of medical or other reasonable accommodation in the pre-approval process.
+- Economy class additional leg room upgrades, such as paying for an emergency row seat upgrade, are available for any person for any duration of flight who is taller than 190 cm (about 6'2") or has a medical condition that requires additional leg room. The Executive Director can make exceptions in case of medical or other reasonable accommodation.
+- Where possible, avoid hiring cars and prefer utilizing cabs or ride share options instead. If a car is the less expensive option than cabs or ride shares, or the only practical option in locations without cabs or ride share, please note this in the expense claim. You are responsible for obtaining all necessary insurance coverage as well as ensuring the least possible fuel cost (i.e. don’t return the car empty).
+- Reimbursement for personal automobile usage for OWASP purposes will be provided at the current IRS mileage rate in the US, or its equivalent outside the US (please provide details of your country’s mileage tax reimbursement in the expense claim). The total reimbursement for mileage must not exceed the cost of economy class airfare for the same trip. The mileage reimbursement rate covers all vehicle expenses, including fuel, insurance, and depreciation.
+
+## Meals and Incidentals
+
+OWASP will reimburse a maximum of $USD 75 per day for meals and incidental expenses based upon receipts, with a cap of $75 per day. If a country is more expensive than usual, this rate may be varied during pre-approval.
+
+## Parking and Highway Tolls
+
+OWASP will reimburse all reasonable parking expenses and highway tolls incurred during travel on behalf of OWASP.
+
+## Miscellaneous Expenses
+
+Miscellaneous OWASP expenses not described above (such as telephone, postage, small supplies on an emergency basis, etc.) will be reimbursed. Laundry and valet expenses are permitted for trips over five days or extended stays, but please consider the use of a laundry service rather than the hotel laundry service.
+
+Purchases of miscellaneous non-travel supplies, software, or computer hardware must adhere to the relevant expense policy and be documented on an expense report.
+
+## Board Entertainment
+
+Members of the board are eligible for reimbursement of essential meals and entertainment expenses incurred in connection with OWASP activities. Expenses must relate directly to OWASP discussions. If in doubt, ask for pre-approval, such as hosting a dinner for corporate supporters, Board dinners, or such as a reception for newcomers.
+
+When reporting on expenditure on entertainment, provide the following:
+
+- Name, title, and organization of the person(s) involved.  
+- Date.  
+- Name and address or location of the restaurant or other facility.  
+- Business reasons; and  
+- The amount of each separate expense, such as the receipt for the meal or bar tab.
+
+Excessive bar tabs may be denied payment (such as more than 50% of a bill), so please submit a pre-approval request where the majority of the bill is likely to be alcohol related.
+
+## Business Gifts by the OWASP Board
+
+If this policy disagrees with the Events Policy, then for solely for events, the Events policy shall take precedence, such as speaker gifts.
+
+Board Members can gift small gifts, such as OWASP merchandise, or similar. Gifts over $USD 100 require prior approval for reimbursement via the pre-approval process.
+
+Most countries have strict anti-bribery laws with serious penalties. When unsure, avoid giving a gift that might be viewed as excessive by local cultural standards. Strictly avoid giving money, gift cards, or similar items as they are considered bribes under anti-bribery laws.
+
+Many countries have biosecurity laws that prevent the importation of food, farm products, and wood. It is advisable to avoid purchasing these gifts since they may not be accepted or might need to be discarded due to travel restrictions.
+
+Large bulky gifts are unlikely to be welcomed by recipients as they will struggle to take them home without hefty excess baggage fees. Avoid purchasing large, bulky gifts.
+
+## Expense Advances
+
+OWASP does not provide cash advances for travel. Regular OWASP travelers should obtain a widely accepted credit card. Interest charges and fees are considered personal expenses and, therefore, will not be reimbursed.
+
+## Pre-approval process
+
+To gain pre-approval for your travel is via creating a Jira ticket in the Payment Approval and Request Service Desk:
+
+- For project leaders, use Project Funding Grant Request or Pre-approval.  
+- For chapter leaders, use Chapter Expense Pre-approval or Grant Funding  
+- For all others, including Board travel, please use Other Funding Pre-approval/Grant.
+
+Once approved, please make your bookings. Small variances between your pre-approval amount and the final ticket price are acceptable. If your booked travel costs are more than about 5% more than the pre-approval, the lesser of the two amounts will be reimbursed, so book promptly once approved. Approval may take up to three business days, and prices vary. Plan your travel early.
+
+## Claiming your travel expenses
+
+To claim your travel expenses, within 30 days of your return from the trip, please create a Jira ticket in the Funding project \> Payment Approval Service Desk, and choose one of the following:
+
+- For project leaders, use Project Funding Grant Request or Pre-approval.  
+- For chapter leaders, use Chapter Expense Pre-approval or Grant Funding.  
+- For all others, including Board travel, please use Other Funding Pre-approval/Grant.
+
+Please include the pre-approval ticket number in your expense claim to ensure reimbursement. If you fail to submit your expense claim within 30 days of your return, your expense claim may be denied. All necessary details and receipts must be submitted to avoid delays in reimbursement.
+
+## Travel assistance
+
+To help perform our mission, if you need travel assistance OWASP might be able to help by paying for your flights and accommodation, or providing a scholarship or grant for qualified individuals, such as students, speakers, trainers, leaders, and Board members. Due to limited funds, please note this when you apply for pre-approval (see above). We may not be able to help you, so please apply for travel assistance as early as you can.

--- a/operational/travel.md
+++ b/operational/travel.md
@@ -10,8 +10,7 @@ notice: 2025-04-28
 
 {% include draft-notice.html %}
 
-OWASP is a global nonprofit organization, with volunteers all over the world. As such, travel is occasionally necessary. Where possible, local volunteers or speakers should be chosen to minimize travel expenses. OWASP will not approve travel if there are local volunteers nearby. Please seek out local volunteers before proceeding with a pre-approval travel request. Travel covered by this policy is needs based, and is not guaranteed simply because the traveler might be an OWASP leader, chosen to speak at an OWASP event, or a participant at a regulatory meeting. Travel pre-approval is more likely if there are budgeted funds available or through fundraising on behalf of the request.
-
+OWASP is a global nonprofit organization, with volunteers all over the world. As such, travel is occasionally necessary. Where possible, local volunteers or speakers should be chosen to minimize travel expenses. OWASP will not approve travel if there are local volunteers nearby. Please seek out local volunteers before proceeding with a pre-approval travel request. Travel covered by this policy is needs-based, and is not guaranteed simply because the traveler might be an OWASP leader, chosen to speak at an OWASP event, or a participant at a regulatory meeting. Travel pre-approval is more likely if there are budgeted funds available or through fundraising on behalf of the request.
 ## Scope
 
 This policy covers Board, volunteer, and participant travel for events, projects, or chapters, such as speakers or invited keynote speakers, project workshops or summits, chapter speakers, and any other pre-approved travel purpose, such as representing OWASP at regulatory bodies or at co-marketing events. All Board and volunteer travel must be pre-approved by the OWASP Foundation.

--- a/operational/travel.md
+++ b/operational/travel.md
@@ -87,8 +87,7 @@ Excessive bar tabs may be denied payment (such as more than 50% of a bill), so p
 
 ## Business Gifts by the OWASP Board
 
-If this policy disagrees with the Events Policy, then for solely for events, the Events policy shall take precedence, such as speaker gifts.
-
+If this policy disagrees with the Events Policy, then solely for events, the Events policy shall take precedence, such as speaker gifts.
 Board Members can gift small gifts, such as OWASP merchandise, or similar. Gifts over $USD 100 require prior approval for reimbursement via the pre-approval process.
 
 Most countries have strict anti-bribery laws with serious penalties. When unsure, avoid giving a gift that might be viewed as excessive by local cultural standards. Strictly avoid giving money, gift cards, or similar items as they are considered bribes under anti-bribery laws.


### PR DESCRIPTION
This policy defines the OWASP travel policy for Board members, volunteers and participants.